### PR TITLE
Add new Streams

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,18 +9,12 @@ setup(
     url="http://singer.io",
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_pardot"],
-    install_requires=[
-        "singer-python==5.8.0",
-        "requests==2.22.0",
-        "backoff==1.8.0"
-    ],
+    install_requires=["singer-python==5.8.0", "requests==2.22.0", "backoff==1.8.0"],
     entry_points="""
     [console_scripts]
     tap-pardot=tap_pardot:main
     """,
     packages=["tap_pardot"],
-    package_data = {
-        "schemas": ["tap_pardot/schemas/*.json"]
-    },
+    package_data={"schemas": ["tap_pardot/schemas/*.json"]},
     include_package_data=True,
 )

--- a/spikes/reading_data.py
+++ b/spikes/reading_data.py
@@ -1,6 +1,6 @@
-
 # We need environment variables
 import os
+
 import requests
 import xmltodict
 
@@ -8,11 +8,11 @@ AUTH_URL = "https://pi.pardot.com/api/login/version/3"
 
 ENDPOINT_BASE = "https://pi.pardot.com/api/"
 
-class Client():
-    """
-    Lightweight Client wrapper to allow switching between version 3 and 4
-    API based on availability, if desired.
-    """
+
+class Client:
+    """Lightweight Client wrapper to allow switching between version 3 and 4 API based
+    on availability, if desired."""
+
     api_version = None
     api_key = None
     creds = None
@@ -25,10 +25,7 @@ class Client():
         "visitorActivity": "visitorActivity/version/{}/do/query",
     }
 
-    describe_map = {
-        "prospectAccount": "prospectAccount/version/{}/do/describe",
-    }
-    
+    describe_map = {"prospectAccount": "prospectAccount/version/{}/do/describe"}
 
     def __init__(self, creds):
         # Do login
@@ -36,30 +33,42 @@ class Client():
         self.login(creds)
 
     def login(self, creds):
-        response = requests.post(AUTH_URL,
-                                 data={
-                                     "email": creds["email"],
-                                     "password": creds["password"],
-                                     "user_key": creds["user_key"]
-                                 },
-                                 params={"format":"json"})
+        response = requests.post(
+            AUTH_URL,
+            data={
+                "email": creds["email"],
+                "password": creds["password"],
+                "user_key": creds["user_key"],
+            },
+            params={"format": "json"},
+        )
 
         # This will only work if they use HTTP codes. Handling Pardot
         # errors below.
         response.raise_for_status()
 
         content = response.json()
-        
+
         error_message = content.get("err")
         if error_message:
-            error_code = content["@attributes"]["err_code"] # E.g., "15" for login failed
-            raise Exception("Pardot returned error code {} while authenticating. Message: {}".format(error_code, error_message))
+            error_code = content["@attributes"][
+                "err_code"
+            ]  # E.g., "15" for login failed
+            raise Exception(
+                "Pardot returned error code {} while authenticating. Message: {}".format(
+                    error_code, error_message
+                )
+            )
 
-        self.api_version = content['version']
-        self.api_key = content['api_key']
+        self.api_version = content["version"]
+        self.api_key = content["api_key"]
 
     def _get_auth_header(self):
-        return {"Authorization": "Pardot api_key={}, user_key={}".format(self.api_key, self.creds["user_key"])}
+        return {
+            "Authorization": "Pardot api_key={}, user_key={}".format(
+                self.api_key, self.creds["user_key"]
+            )
+        }
 
     def describe(self, endpoint, **kwargs):
 
@@ -68,16 +77,13 @@ class Client():
         if describe_url is None:
             raise Exception("No describe operation for endpoint {}".format(endpoint))
 
-
         url = (ENDPOINT_BASE + describe_url).format(self.api_version)
 
         headers = self._get_auth_header()
-        response = requests.get(url,
-                                 headers=headers,
-                                 params={"format":"json",
-                                         "output": "bulk",
-                                         **kwargs})
-        
+        response = requests.get(
+            url, headers=headers, params={"format": "json", "output": "bulk", **kwargs}
+        )
+
         return response
 
     def get(self, endpoint, format_params=None, **kwargs):
@@ -97,13 +103,12 @@ class Client():
         # TODO: In implementation, log the request (sanitized) at this point
         headers = self._get_auth_header()
 
-        response = requests.get(url,
-                                 headers=headers,
-                                 params={"format":"json",
-                                         "output": "bulk",
-                                         **kwargs})
+        response = requests.get(
+            url, headers=headers, params={"format": "json", "output": "bulk", **kwargs}
+        )
 
         return response
+
 
 config = {
     "email": os.getenv("PARDOT_EMAIL"),
@@ -119,12 +124,12 @@ test = Client(config)
 
 #### Email Click Example
 # Since it can't be sorted, we _can_ page by a window
-#val = test.get('emailClick', **{"created_after":"2019-08-01", "created_before":"2019-08-02"})
+# val = test.get('emailClick', **{"created_after":"2019-08-01", "created_before":"2019-08-02"})
 
 # Email Click appears to be sorted by ID, this can be used for pagination and bookmarking
 # WARNING: When writing the tap, you MUST assert this is true
-#bookmark_id = None
-#val = test.get('emailClick', **{"created_after":"2019-08-01", "created_before":"2019-08-02", "id_greater_than":bookmark_id or 0})
+# bookmark_id = None
+# val = test.get('emailClick', **{"created_after":"2019-08-01", "created_before":"2019-08-02", "id_greater_than":bookmark_id or 0})
 
 # Bookmarking on ID with start_date as the lower-bound on created_after
 # This is what that pattern could look like with `start_date: 2018-08-01`
@@ -136,7 +141,7 @@ test = Client(config)
 # 435007531
 
 #### Prospect Accounts Example
-#val = test.get("prospectAccount", **{"updated_after": "2019-08-01", "sort_by": "updated_at", "sort_order": "ascending"})
+# val = test.get("prospectAccount", **{"updated_after": "2019-08-01", "sort_by": "updated_at", "sort_order": "ascending"})
 
 # WARNING: Validate that the sort order is appropriately applied.
 # `update_at` comes back in this format '2019-03-22 11:26:02'
@@ -147,11 +152,11 @@ test = Client(config)
 # account has a null value it is returned as None
 
 #### Visitor Activity Example
-#val = test.get("visitorActivity", **{"created_after": "2019-08-01", "sort_by": "created_at", "sort_order": "ascending"})
+# val = test.get("visitorActivity", **{"created_after": "2019-08-01", "sort_by": "created_at", "sort_order": "ascending"})
 
 # val.json()['result']['visitor_activity']
 
 # These appear to be immutable, so bookmark and sort on created_at
 
-#import pdb
+# import pdb
 pdb.set_trace()

--- a/tap_pardot/__init__.py
+++ b/tap_pardot/__init__.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
+
 import singer
-import json
-from singer.catalog import write_catalog
 from singer import utils
+from singer.catalog import write_catalog
+
 from .client import Client
 from .discover import discover
 from .sync import sync
@@ -10,6 +11,7 @@ from .sync import sync
 LOGGER = singer.get_logger()
 
 REQUIRED_CONFIG_KEYS = ["start_date", "email", "password", "user_key"]
+
 
 @utils.handle_top_exception(LOGGER)
 def main():
@@ -30,9 +32,10 @@ def main():
         if args.catalog:
             catalog = args.catalog
         else:
-            catalog =  discover(client)
+            catalog = discover(client)
 
         sync(client, args.config, args.state, catalog)
+
 
 if __name__ == "__main__":
     main()

--- a/tap_pardot/client.py
+++ b/tap_pardot/client.py
@@ -29,15 +29,9 @@ class Client:
     api_version = None
     api_key = None
     creds = None
-    TEST_URL = None
 
-    endpoint_map = {
-        "email_clicks": "emailClick/version/{}/do/query",
-        "prospect_accounts": "prospectAccount/version/{}/do/query",
-        "visitor_activities": "visitorActivity/version/{}/do/query",
-    }
-
-    describe_map = {"prospect_accounts": "prospectAccount/version/{}/do/describe"}
+    get_url = "{}/version/{}/do/query"
+    describe_url = "{}/version/{}/do/describe"
 
     def __init__(self, creds):
         self.creds = creds
@@ -108,13 +102,7 @@ class Client:
         jitter=None,
     )
     def describe(self, endpoint, **kwargs):
-
-        describe_url = self.describe_map.get(endpoint)
-
-        if describe_url is None:
-            raise Exception("No describe operation for endpoint {}".format(endpoint))
-
-        url = (ENDPOINT_BASE + describe_url).format(self.api_version)
+        url = (ENDPOINT_BASE + self.describe_url).format(endpoint, self.api_version)
 
         headers = self._get_auth_header()
         params = {"format": "json", "output": "bulk", **kwargs}
@@ -152,11 +140,10 @@ class Client:
         # Error code 1 indicates a bad api_key or user_key
         # If we get error code 1 then re-authenticate login
         # http://developer.pardot.com/kb/error-codes-messages/#error-code-1
-        url = ENDPOINT_BASE + self.endpoint_map[endpoint]
-        base_formatting = [self.api_version]
+        base_formatting = [endpoint, self.api_version]
         if format_params:
             base_formatting.extend(format_params)
-        url = url.format(*base_formatting)
+        url = (ENDPOINT_BASE + self.get_url).format(*base_formatting)
 
         headers = self._get_auth_header()
         params = {"format": "json", "output": "bulk", **kwargs}

--- a/tap_pardot/client.py
+++ b/tap_pardot/client.py
@@ -1,5 +1,5 @@
-import requests
 import backoff
+import requests
 import singer
 
 LOGGER = singer.get_logger()
@@ -7,11 +7,13 @@ LOGGER = singer.get_logger()
 AUTH_URL = "https://pi.pardot.com/api/login/version/3"
 ENDPOINT_BASE = "https://pi.pardot.com/api/"
 
+
 class PardotException(Exception):
     def __init__(self, message, response_content):
         self.code = response_content.get("@attributes", {}).get("err_code")
         self.response = response_content
         super().__init__(message)
+
 
 def is_not_retryable_pardot_exception(exc):
     if exc.code == 66:
@@ -19,11 +21,11 @@ def is_not_retryable_pardot_exception(exc):
         return False
     return True
 
-class Client():
-    """
-    Lightweight Client wrapper to allow switching between version 3 and 4
-    API based on availability, if desired.
-    """
+
+class Client:
+    """Lightweight Client wrapper to allow switching between version 3 and 4 API based
+    on availability, if desired."""
+
     api_version = None
     api_key = None
     creds = None
@@ -35,38 +37,50 @@ class Client():
         "visitor_activities": "visitorActivity/version/{}/do/query",
     }
 
-    describe_map = {
-        "prospect_accounts": "prospectAccount/version/{}/do/describe",
-    }
+    describe_map = {"prospect_accounts": "prospectAccount/version/{}/do/describe"}
 
     def __init__(self, creds):
         self.creds = creds
         self.login()
 
     def login(self):
-        response = requests.post(AUTH_URL,
-                                 data={
-                                     "email": self.creds["email"],
-                                     "password": self.creds["password"],
-                                     "user_key": self.creds["user_key"]
-                                 },
-                                 params={"format":"json"})
+        response = requests.post(
+            AUTH_URL,
+            data={
+                "email": self.creds["email"],
+                "password": self.creds["password"],
+                "user_key": self.creds["user_key"],
+            },
+            params={"format": "json"},
+        )
 
         # This will only work if they use HTTP codes. Handling Pardot
         # errors below.
         response.raise_for_status()
 
         content = response.json()
-        
+
         error_message = content.get("err")
         if error_message:
-            error_code = content["@attributes"]["err_code"] # E.g., "15" for login failed
-            raise PardotException("Pardot returned error code {} while authenticating. Message: {}".format(error_code, error_message), content)
+            error_code = content["@attributes"][
+                "err_code"
+            ]  # E.g., "15" for login failed
+            raise PardotException(
+                "Pardot returned error code {} while authenticating. Message: {}".format(
+                    error_code, error_message
+                ),
+                content,
+            )
 
-        self.api_version = content.get('version') or "3"
-        self.api_key = content['api_key']
+        self.api_version = content.get("version") or "3"
+        self.api_key = content["api_key"]
+
     def _get_auth_header(self):
-        return {"Authorization": "Pardot api_key={}, user_key={}".format(self.api_key, self.creds["user_key"])}
+        return {
+            "Authorization": "Pardot api_key={}, user_key={}".format(
+                self.api_key, self.creds["user_key"]
+            )
+        }
 
     def _make_request(self, url, headers=None, params=None):
         response = requests.get(url, headers=headers, params=params)
@@ -75,7 +89,9 @@ class Client():
         error_message = content.get("err")
 
         if error_message:
-            error_code = content["@attributes"]["err_code"] # Error code of 1 is an expired api_key or user_key
+            error_code = content["@attributes"][
+                "err_code"
+            ]  # Error code of 1 is an expired api_key or user_key
 
             if error_code == 1:
                 LOGGER.info("API key or user key expired -- Reauthenticating once")
@@ -84,11 +100,13 @@ class Client():
                 content = response.json()
 
         return content
-    
-    @backoff.on_exception(backoff.expo,
-                          (PardotException),
-                          giveup=is_not_retryable_pardot_exception,
-                          jitter=None)
+
+    @backoff.on_exception(
+        backoff.expo,
+        (PardotException),
+        giveup=is_not_retryable_pardot_exception,
+        jitter=None,
+    )
     def describe(self, endpoint, **kwargs):
 
         describe_url = self.describe_map.get(endpoint)
@@ -99,22 +117,36 @@ class Client():
         url = (ENDPOINT_BASE + describe_url).format(self.api_version)
 
         headers = self._get_auth_header()
-        params={"format":"json", "output": "bulk", **kwargs}
-        
-        LOGGER.info("%s - Making request to GET endpoint %s, with params %s", endpoint, url, params)
+        params = {"format": "json", "output": "bulk", **kwargs}
+
+        LOGGER.info(
+            "%s - Making request to GET endpoint %s, with params %s",
+            endpoint,
+            url,
+            params,
+        )
         content = self._make_request(url, headers, params)
-        
+
         error_message = content.get("err")
         if error_message:
-            error_code = content["@attributes"]["err_code"] # E.g., "15" for login failed
-            raise PardotException("{} - Pardot returned error code {} while describing endpoint. Message: {}".format(endpoint, error_code, error_message), content)
+            error_code = content["@attributes"][
+                "err_code"
+            ]  # E.g., "15" for login failed
+            raise PardotException(
+                "{} - Pardot returned error code {} while describing endpoint. Message: {}".format(
+                    endpoint, error_code, error_message
+                ),
+                content,
+            )
 
         return content
 
-    @backoff.on_exception(backoff.expo,
-                          (PardotException),
-                          giveup=is_not_retryable_pardot_exception,
-                          jitter=None)
+    @backoff.on_exception(
+        backoff.expo,
+        (PardotException),
+        giveup=is_not_retryable_pardot_exception,
+        jitter=None,
+    )
     def get(self, endpoint, format_params=None, **kwargs):
         # Not worrying about a backoff pattern for the spike
         # Error code 1 indicates a bad api_key or user_key
@@ -127,14 +159,26 @@ class Client():
         url = url.format(*base_formatting)
 
         headers = self._get_auth_header()
-        params={"format":"json", "output": "bulk", **kwargs}
+        params = {"format": "json", "output": "bulk", **kwargs}
 
-        LOGGER.info("%s - Making request to GET endpoint %s, with params %s", endpoint, url, params)
+        LOGGER.info(
+            "%s - Making request to GET endpoint %s, with params %s",
+            endpoint,
+            url,
+            params,
+        )
         content = self._make_request(url, headers, params)
-        
+
         error_message = content.get("err")
         if error_message:
-            error_code = content["@attributes"]["err_code"] # E.g., "15" for login failed
-            raise PardotException("{} - Pardot returned error code {} while retreiving endpoint. Message: {}".format(endpoint, error_code, error_message), content)
+            error_code = content["@attributes"][
+                "err_code"
+            ]  # E.g., "15" for login failed
+            raise PardotException(
+                "{} - Pardot returned error code {} while retreiving endpoint. Message: {}".format(
+                    endpoint, error_code, error_message
+                ),
+                content,
+            )
 
         return content

--- a/tap_pardot/client.py
+++ b/tap_pardot/client.py
@@ -62,9 +62,7 @@ class Client:
     def _check_error(self, content, activity):
         error_message = content.get("err")
         if error_message:
-            error_code = content["@attributes"][
-                "err_code"
-            ]  # E.g., "15" for login failed
+            error_code = content["@attributes"]["err_code"]
             raise PardotException(
                 "Pardot returned error code {} while {}. Message: {}".format(
                     error_code, activity, error_message
@@ -95,9 +93,11 @@ class Client:
         error_message = content.get("err")
 
         if error_message:
-            error_code = content["@attributes"][
-                "err_code"
-            ]  # Error code of 1 is an expired api_key or user_key
+            error_code = content["@attributes"]["err_code"]
+
+            # Error code 1 indicates a bad api_key or user_key
+            # If we get error code 1 then re-authenticate login
+            # http://developer.pardot.com/kb/error-codes-messages/#error-code-1
 
             if error_code == 1:
                 LOGGER.info("API key or user key expired -- Reauthenticating once")
@@ -133,10 +133,6 @@ class Client:
         jitter=None,
     )
     def _fetch(self, method, endpoint, format_params, **kwargs):
-        # Not worrying about a backoff pattern for the spike
-        # Error code 1 indicates a bad api_key or user_key
-        # If we get error code 1 then re-authenticate login
-        # http://developer.pardot.com/kb/error-codes-messages/#error-code-1
         base_formatting = [endpoint, self.api_version]
         if format_params:
             base_formatting.extend(format_params)

--- a/tap_pardot/discover.py
+++ b/tap_pardot/discover.py
@@ -1,9 +1,12 @@
 import json
 import os
 
+import singer
 from singer import Catalog, metadata
 
 from .streams import STREAM_OBJECTS
+
+LOGGER = singer.get_logger()
 
 
 def _get_abs_path(path):
@@ -50,6 +53,7 @@ def _load_schemas(client):
 
 
 def discover(client):
+    LOGGER.info("Starting discovery mode")
     raw_schemas = _load_schemas(client)
     streams = []
 

--- a/tap_pardot/discover.py
+++ b/tap_pardot/discover.py
@@ -34,9 +34,10 @@ def _load_schemas(client):
             schemas[file_raw] = json.load(file)
 
     for stream in schemas.keys():
-        if STREAM_OBJECTS[stream].is_dynamic:
+        stream_object = STREAM_OBJECTS[stream]
+        if stream_object.is_dynamic:
             # Client describe
-            schema_response = client.describe(stream)
+            schema_response = client.describe(stream_object.endpoint)
             # Parse Result into JSON Schema
             dynamic_schema_parts = _parse_schema_description(schema_response)
             # Add to schemas

--- a/tap_pardot/discover.py
+++ b/tap_pardot/discover.py
@@ -68,6 +68,7 @@ def discover(client):
                 schema=schema,
                 key_properties=stream.key_properties,
                 valid_replication_keys=stream.replication_keys,
+                replication_method=stream.replication_method,
             ),
             "key_properties": stream.key_properties,
         }

--- a/tap_pardot/discover.py
+++ b/tap_pardot/discover.py
@@ -1,34 +1,35 @@
-import os
 import json
-from singer import metadata, Catalog
+import os
+
+from singer import Catalog, metadata
+
 from .streams import STREAM_OBJECTS
+
 
 def _get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
 
+
 def _parse_schema_description(description):
     subschemas = {}
-    for field in description['result']['field']:
+    for field in description["result"]["field"]:
         # NB: Some fields have been observed to come through as objects.
         #     This was seen on type of 'dropdown' and 'text' with a value
         #     of either a string or integer, so these schemas are merged.
         subschemas[field["@attributes"]["id"]] = {
             "type": ["null", "string", "object"],
-            "properties": {
-                "value": {
-                    "type": ["null", "integer", "string"]
-                }
-            }
+            "properties": {"value": {"type": ["null", "integer", "string"]}},
         }
     return subschemas
+
 
 # Load schemas from schemas folder
 def _load_schemas(client):
     schemas = {}
 
-    for filename in os.listdir(_get_abs_path('schemas')):
-        path = _get_abs_path('schemas') + '/' + filename
-        file_raw = filename.replace('.json', '')
+    for filename in os.listdir(_get_abs_path("schemas")):
+        path = _get_abs_path("schemas") + "/" + filename
+        file_raw = filename.replace(".json", "")
         with open(path) as file:
             schemas[file_raw] = json.load(file)
 
@@ -39,10 +40,13 @@ def _load_schemas(client):
             # Parse Result into JSON Schema
             dynamic_schema_parts = _parse_schema_description(schema_response)
             # Add to schemas
-            schemas[stream] = {"type": "object",
-                               "properties": {**schemas[stream]["properties"], **dynamic_schema_parts}}
+            schemas[stream] = {
+                "type": "object",
+                "properties": {**schemas[stream]["properties"], **dynamic_schema_parts},
+            }
 
     return schemas
+
 
 def discover(client):
     raw_schemas = _load_schemas(client)
@@ -52,13 +56,15 @@ def discover(client):
         # create and add catalog entry
         stream = STREAM_OBJECTS[stream_name]
         catalog_entry = {
-            'stream': stream_name,
-            'tap_stream_id': stream_name,
-            'schema': schema,
-            'metadata' : metadata.get_standard_metadata(schema=schema,
-                                                        key_properties=stream.key_properties,
-                                                        valid_replication_keys=stream.replication_keys),
-            'key_properties': stream.key_properties
+            "stream": stream_name,
+            "tap_stream_id": stream_name,
+            "schema": schema,
+            "metadata": metadata.get_standard_metadata(
+                schema=schema,
+                key_properties=stream.key_properties,
+                valid_replication_keys=stream.replication_keys,
+            ),
+            "key_properties": stream.key_properties,
         }
         streams.append(catalog_entry)
 

--- a/tap_pardot/schemas/campaigns.json
+++ b/tap_pardot/schemas/campaigns.json
@@ -1,0 +1,14 @@
+{
+  "type": ["null", "object"],
+  "properties": {
+    "id": {
+      "type": ["integer"]
+    },
+    "name": {
+      "type": ["null", "string"]
+    },
+    "cost": {
+      "type": ["null", "integer"]
+    }
+  }
+}

--- a/tap_pardot/schemas/list_memberships.json
+++ b/tap_pardot/schemas/list_memberships.json
@@ -1,0 +1,25 @@
+{
+  "type": ["null", "object"],
+  "properties": {
+    "id": {
+      "type": ["integer"]
+    },
+    "list_id": {
+      "type": ["integer"]
+    },
+    "prospect_id": {
+      "type": ["integer"]
+    },
+    "opted_out": {
+      "type": ["null", "integer"]
+    },
+    "created_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    }
+  }
+}

--- a/tap_pardot/schemas/lists.json
+++ b/tap_pardot/schemas/lists.json
@@ -1,0 +1,34 @@
+{
+  "type": ["null", "object"],
+  "properties": {
+    "id": {
+      "type": ["integer"]
+    },
+    "name": {
+      "type": ["null", "string"]
+    },
+    "is_public": {
+      "type": ["null", "boolean"]
+    },
+    "is_dynamic": {
+      "type": ["null", "boolean"]
+    },
+    "title": {
+      "type": ["null", "string"]
+    },
+    "description": {
+      "type": ["null", "string"]
+    },
+    "is_crm_visible": {
+      "type": ["null", "boolean"]
+    },
+    "created_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    }
+  }
+}

--- a/tap_pardot/schemas/opportunities.json
+++ b/tap_pardot/schemas/opportunities.json
@@ -1,0 +1,41 @@
+{
+  "type": ["null", "object"],
+  "properties": {
+    "id": {
+      "type": ["integer"]
+    },
+    "campaign_id": {
+      "type": ["null", "integer"]
+    },
+    "name": {
+      "type": ["null", "string"]
+    },
+    "value": {
+      "type": ["null", "number"]
+    },
+    "probability": {
+      "type": ["null", "integer"]
+    },
+    "type": {
+      "type": ["null", "string"]
+    },
+    "stage": {
+      "type": ["null", "string"]
+    },
+    "status": {
+      "type": ["null", "string"]
+    },
+    "closed_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "created_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    }
+  }
+}

--- a/tap_pardot/schemas/prospects.json
+++ b/tap_pardot/schemas/prospects.json
@@ -1,0 +1,144 @@
+{
+  "type": ["null", "object"],
+  "properties": {
+    "id": {
+      "type": ["integer"]
+    },
+    "campaign_id": {
+      "type": ["null", "integer"]
+    },
+    "salutation": {
+      "type": ["null", "string"]
+    },
+    "first_name": {
+      "type": ["null", "string"]
+    },
+    "last_name": {
+      "type": ["null", "string"]
+    },
+    "email": {
+      "type": ["null", "string"]
+    },
+    "password": {
+      "type": ["null", "string"]
+    },
+    "company": {
+      "type": ["null", "string"]
+    },
+    "prospect_account_id": {
+      "type": ["null", "integer"]
+    },
+    "website": {
+      "type": ["null", "string"]
+    },
+    "job_title": {
+      "type": ["null", "string"]
+    },
+    "department": {
+      "type": ["null", "string"]
+    },
+    "country": {
+      "type": ["null", "string"]
+    },
+    "address_one": {
+      "type": ["null", "string"]
+    },
+    "address_two": {
+      "type": ["null", "string"]
+    },
+    "city": {
+      "type": ["null", "string"]
+    },
+    "state": {
+      "type": ["null", "string"]
+    },
+    "territory": {
+      "type": ["null", "string"]
+    },
+    "zip": {
+      "type": ["null", "string"]
+    },
+    "phone": {
+      "type": ["null", "string"]
+    },
+    "fax": {
+      "type": ["null", "string"]
+    },
+    "source": {
+      "type": ["null", "string"]
+    },
+    "annual_revenue": {
+      "type": ["null", "string"]
+    },
+    "employees": {
+      "type": ["null", "string"]
+    },
+    "industry": {
+      "type": ["null", "string"]
+    },
+    "years_in_business": {
+      "type": ["null", "string"]
+    },
+    "comments": {
+      "type": ["null", "string"]
+    },
+    "notes": {
+      "type": ["null", "string"]
+    },
+    "score": {
+      "type": ["null", "integer"]
+    },
+    "grade": {
+      "type": ["null", "string"]
+    },
+    "last_activity_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "recent_interaction": {
+      "type": ["null", "string"]
+    },
+    "crm_lead_fid": {
+      "type": ["null", "string"]
+    },
+    "crm_contact_fid": {
+      "type": ["null", "string"]
+    },
+    "crm_owner_fid": {
+      "type": ["null", "string"]
+    },
+    "crm_account_fid": {
+      "type": ["null", "string"]
+    },
+    "crm_last_sync": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "crm_url": {
+      "type": ["null", "string"]
+    },
+    "is_do_not_email": {
+      "type": ["null", "boolean"]
+    },
+    "is_do_not_call": {
+      "type": ["null", "boolean"]
+    },
+    "opted_out": {
+      "type": ["null", "boolean"]
+    },
+    "is_reviewed": {
+      "type": ["null", "boolean"]
+    },
+    "is_starred": {
+      "type": ["null", "boolean"]
+    },
+    "created_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    }
+  }
+}

--- a/tap_pardot/schemas/users.json
+++ b/tap_pardot/schemas/users.json
@@ -1,0 +1,31 @@
+{
+  "type": ["null", "object"],
+  "properties": {
+    "id": {
+      "type": ["integer"]
+    },
+    "email": {
+      "type": ["null", "string"]
+    },
+    "first_name": {
+      "type": ["null", "string"]
+    },
+    "last_name": {
+      "type": ["null", "string"]
+    },
+    "job_title": {
+      "type": ["null", "string"]
+    },
+    "role": {
+      "type": ["null", "string"]
+    },
+    "created_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    }
+  }
+}

--- a/tap_pardot/schemas/visitors.json
+++ b/tap_pardot/schemas/visitors.json
@@ -1,0 +1,40 @@
+{
+  "type": ["null", "object"],
+  "properties": {
+    "id": {
+      "type": ["integer"]
+    },
+    "page_view_count": {
+      "type": ["null", "integer"]
+    },
+    "ip_address": {
+      "type": ["null", "string"]
+    },
+    "hostname": {
+      "type": ["null", "string"]
+    },
+    "campaign_parameter": {
+      "type": ["null", "string"]
+    },
+    "medium_parameter": {
+      "type": ["null", "string"]
+    },
+    "source_parameter": {
+      "type": ["null", "string"]
+    },
+    "content_parameter": {
+      "type": ["null", "string"]
+    },
+    "term_parameter": {
+      "type": ["null", "string"]
+    },
+    "created_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    }
+  }
+}

--- a/tap_pardot/schemas/visits.json
+++ b/tap_pardot/schemas/visits.json
@@ -1,0 +1,51 @@
+{
+  "type": ["null", "object"],
+  "properties": {
+    "id": {
+      "type": ["integer"]
+    },
+    "visitor_id": {
+      "type": ["null", "integer"]
+    },
+    "prospect_id": {
+      "type": ["null", "integer"]
+    },
+    "visitor_page_view_count": {
+      "type": ["null", "integer"]
+    },
+    "first_visitor_page_view_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "last_visitor_page_view_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "duration_in_seconds": {
+      "type": ["null", "integer"]
+    },
+    "campaign_parameter": {
+      "type": ["null", "string"]
+    },
+    "medium_parameter": {
+      "type": ["null", "string"]
+    },
+    "source_parameter": {
+      "type": ["null", "string"]
+    },
+    "content_parameter": {
+      "type": ["null", "string"]
+    },
+    "term_parameter": {
+      "type": ["null", "string"]
+    },
+    "created_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    }
+  }
+}

--- a/tap_pardot/schemas/visits.json
+++ b/tap_pardot/schemas/visits.json
@@ -13,6 +13,32 @@
     "visitor_page_view_count": {
       "type": ["null", "integer"]
     },
+    "visitor_page_views": {
+      "type": ["null", "object"],
+      "properties": {
+        "visitor_page_view": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["null", "object"],
+            "properties": {
+              "url": {
+                "type": ["null", "string"]
+              },
+              "created_at": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "id": {
+                "type": ["integer"]
+              },
+              "title": {
+                "type": ["null", "string"]
+              }
+            }
+          }
+        }
+      }
+    },
     "first_visitor_page_view_at": {
       "type": ["null", "string"],
       "format": "date-time"

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -394,6 +394,16 @@ class Visits(ChildStream):
     parent_class = Visitors
     parent_id_param = "visitor_ids"
 
+    def fix_page_views(self, record):
+        page_views = record["visitor_page_views"]["visitor_page_view"]
+        if isinstance(page_views, dict):
+            record["visitor_page_views"]["visitor_page_view"] = [page_views]
+
+    def sync_page(self, parent_ids):
+        for rec in self.get_records(parent_ids):
+            self.fix_page_views(rec)
+            yield rec
+
 
 class Lists(UpdatedAtReplicationStream):
     stream_name = "lists"

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -119,12 +119,10 @@ class ProspectAccounts(Stream):
         }
 
 
-##############
-# NEW STREAMS
-##############
-class Campaign(Stream):
-    stream_name = "campaign"
-    data_key = "campaign"
+class Prospects(Stream):
+    stream_name = "prospects"
+    data_key = "prospect"
+    endpoint = "prospect"
     replication_keys = ["updated_at"]
     key_properties = ["id"]
     is_dynamic = False

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -1,3 +1,5 @@
+import inspect
+
 import singer
 
 
@@ -131,8 +133,7 @@ class Campaign(Stream):
 
 
 STREAM_OBJECTS = {
-    "email_clicks": EmailClicks,
-    "visitor_activities": VisitorActivities,
-    "prospect_accounts": ProspectAccounts,
-    "campaign": Campaign,
+    cls.stream_name: cls
+    for cls in globals().values()
+    if inspect.isclass(cls) and issubclass(cls, Stream) and cls.stream_name
 }

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -131,6 +131,14 @@ class Opportunities(UpdatedAtReplicationStream):
     is_dynamic = False
 
 
+class Users(UpdatedAtReplicationStream):
+    stream_name = "users"
+    data_key = "user"
+    endpoint = "user"
+
+    is_dynamic = False
+
+
 STREAM_OBJECTS = {
     cls.stream_name: cls
     for cls in globals().values()

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -9,6 +9,7 @@ class Stream:
     endpoint = None
     key_properties = ["id"]
     replication_keys = []
+    replication_method = None
     is_dynamic = False
 
     client = None
@@ -69,6 +70,7 @@ class Stream:
 
 class IdReplicationStream(Stream):
     replication_keys = ["id"]
+    replication_method = "INCREMENTAL"
 
     def get_default_start(self):
         return 0
@@ -77,11 +79,14 @@ class IdReplicationStream(Stream):
         return {
             "created_after": self.config["start_date"],
             "id_greater_than": self.get_bookmark(),
+            "sort_by": "id",
+            "sort_order": "ascending",
         }
 
 
 class UpdatedAtReplicationStream(Stream):
     replication_keys = ["updated_at"]
+    replication_method = "INCREMENTAL"
 
     def get_params(self):
         return {

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -16,7 +16,7 @@ class Stream:
     config = None
     state = None
 
-    _last_value = None
+    _last_bookmark_value = None
 
     def __init__(self, client, config, state):
         self.client = client
@@ -60,18 +60,18 @@ class Stream:
             records = [records]
         return records
 
-    def check_order(self, current_value):
-        if self._last_value is None:
-            self._last_value = current_value
+    def check_order(self, current_bookmark_value):
+        if self._last_bookmark_value is None:
+            self._last_bookmark_value = current_bookmark_value
 
-        if current_value < self._last_value:
+        if current_bookmark_value < self._last_bookmark_value:
             raise Exception(
                 "Detected out of order data. Current bookmark value {} is less than last bookmark value {}".format(
-                    current_value, self._last_value
+                    current_bookmark_value, self._last_bookmark_value
                 )
             )
 
-        self._last_value = current_value
+        self._last_bookmark_value = current_bookmark_value
 
     def sync_page(self):
         for rec in self.get_records():

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -135,6 +135,22 @@ class Prospects(Stream):
         }
 
 
+class Opportunities(Stream):
+    stream_name = "opportunities"
+    data_key = "opportunity"
+    endpoint = "opportunity"
+    replication_keys = ["updated_at"]
+    key_properties = ["id"]
+    is_dynamic = False
+
+    def get_params(self):
+        return {
+            "updated_after": self.get_bookmark(),
+            "sort_by": "updated_at",
+            "sort_order": "ascending",
+        }
+
+
 STREAM_OBJECTS = {
     cls.stream_name: cls
     for cls in globals().values()

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -18,10 +18,11 @@ class Stream:
 
     _last_bookmark_value = None
 
-    def __init__(self, client, config, state):
+    def __init__(self, client, config, state, emit=True):
         self.client = client
         self.state = state
         self.config = config
+        self.emit = emit
 
     def get_default_start(self):
         return self.config["start_date"]
@@ -41,7 +42,8 @@ class Stream:
         singer.bookmarks.write_bookmark(
             self.state, self.stream_name, self.replication_keys[0], bookmark_value
         )
-        singer.write_state(self.state)
+        if self.emit:
+            singer.write_state(self.state)
 
     def pre_sync(self):
         """Function to run arbitrary code before a full sync starts."""
@@ -147,7 +149,8 @@ class ComplexBookmarkStream(Stream):
 
     def clear_bookmark(self, bookmark_key):
         singer.bookmarks.clear_bookmark(self.state, self.stream_name, bookmark_key)
-        singer.write_state(self.state)
+        if self.emit:
+            singer.write_state(self.state)
 
     def get_bookmark(self, bookmark_key):
         return singer.bookmarks.get_bookmark(self.state, self.stream_name, bookmark_key)
@@ -156,7 +159,8 @@ class ComplexBookmarkStream(Stream):
         singer.bookmarks.write_bookmark(
             self.state, self.stream_name, bookmark_key, bookmark_value
         )
-        singer.write_state(self.state)
+        if self.emit:
+            singer.write_state(self.state)
 
     def sync_page(self):
         raise NotImplementedError("ComplexBookmarkStreams need a custom sync method.")

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -6,12 +6,14 @@ import singer
 class Stream:
     stream_name = None
     data_key = None
+    endpoint = None
     key_properties = []
     replication_keys = []
+    is_dynamic = False
+
     client = None
     config = None
     state = None
-    is_dynamic = False
 
     def __init__(self, client, config, state):
         self.client = client
@@ -39,7 +41,7 @@ class Stream:
         singer.write_state(self.state)
 
     def sync(self):
-        data = self.client.get(self.stream_name, **self.get_params())
+        data = self.client.get(self.endpoint, **self.get_params())
 
         if data["result"] is None or data["result"].get("total_results") == 0:
             return
@@ -67,8 +69,9 @@ class Stream:
 
 class EmailClicks(Stream):
     stream_name = "email_clicks"
-    replication_keys = ["id"]
     data_key = "emailClick"
+    endpoint = "emailClick"
+    replication_keys = ["id"]
     key_properties = ["id"]
     is_dynamic = False
 
@@ -85,6 +88,7 @@ class EmailClicks(Stream):
 class VisitorActivities(Stream):
     stream_name = "visitor_activities"
     data_key = "visitor_activity"
+    endpoint = "visitorActivity"
     replication_keys = ["id"]
     key_properties = ["id"]
     is_dynamic = False
@@ -102,6 +106,7 @@ class VisitorActivities(Stream):
 class ProspectAccounts(Stream):
     stream_name = "prospect_accounts"
     data_key = "prospectAccount"
+    endpoint = "prospectAccount"
     replication_keys = ["updated_at"]
     key_properties = ["id"]
     is_dynamic = True

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -307,6 +307,14 @@ class Users(NoUpdatedAtSortingStream):
     is_dynamic = False
 
 
+class Lists(UpdatedAtReplicationStream):
+    stream_name = "lists"
+    data_key = "list"
+    endpoint = "list"
+
+    is_dynamic = False
+
+
 class ListMemberships(NoUpdatedAtSortingStream):
     stream_name = "list_memberships"
     data_key = "list_membership"

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -7,7 +7,7 @@ class Stream:
     stream_name = None
     data_key = None
     endpoint = None
-    key_properties = []
+    key_properties = ["id"]
     replication_keys = []
     is_dynamic = False
 
@@ -67,88 +67,68 @@ class Stream:
             yield rec
 
 
-class EmailClicks(Stream):
+class IdReplicationStream(Stream):
+    replication_keys = ["id"]
+
+    def get_default_start(self):
+        return 0
+
+    def get_params(self):
+        return {
+            "created_after": self.config["start_date"],
+            "id_greater_than": self.get_bookmark(),
+        }
+
+
+class UpdatedAtReplicationStream(Stream):
+    replication_keys = ["updated_at"]
+
+    def get_params(self):
+        return {
+            "updated_after": self.get_bookmark(),
+            "sort_by": "updated_at",
+            "sort_order": "ascending",
+        }
+
+
+class EmailClicks(IdReplicationStream):
     stream_name = "email_clicks"
     data_key = "emailClick"
     endpoint = "emailClick"
-    replication_keys = ["id"]
-    key_properties = ["id"]
+
     is_dynamic = False
 
-    def get_default_start(self):
-        return 0
 
-    def get_params(self):
-        return {
-            "created_after": self.config["start_date"],
-            "id_greater_than": self.get_bookmark(),
-        }
-
-
-class VisitorActivities(Stream):
+class VisitorActivities(IdReplicationStream):
     stream_name = "visitor_activities"
     data_key = "visitor_activity"
     endpoint = "visitorActivity"
-    replication_keys = ["id"]
-    key_properties = ["id"]
+
     is_dynamic = False
 
-    def get_default_start(self):
-        return 0
 
-    def get_params(self):
-        return {
-            "created_after": self.config["start_date"],
-            "id_greater_than": self.get_bookmark(),
-        }
-
-
-class ProspectAccounts(Stream):
+class ProspectAccounts(UpdatedAtReplicationStream):
     stream_name = "prospect_accounts"
     data_key = "prospectAccount"
     endpoint = "prospectAccount"
-    replication_keys = ["updated_at"]
-    key_properties = ["id"]
+
     is_dynamic = True
 
-    def get_params(self):
-        return {
-            "updated_after": self.get_bookmark(),
-            "sort_by": "updated_at",
-            "sort_order": "ascending",
-        }
 
-
-class Prospects(Stream):
+class Prospects(UpdatedAtReplicationStream):
     stream_name = "prospects"
     data_key = "prospect"
     endpoint = "prospect"
-    replication_keys = ["updated_at"]
-    key_properties = ["id"]
+
     is_dynamic = False
 
-    def get_params(self):
-        return {
-            "updated_after": self.get_bookmark(),
-            "sort_by": "updated_at",
-            "sort_order": "ascending",
-        }
 
-
-class Opportunities(Stream):
+class Opportunities(UpdatedAtReplicationStream):
     stream_name = "opportunities"
     data_key = "opportunity"
     endpoint = "opportunity"
-    replication_keys = ["updated_at"]
-    key_properties = ["id"]
-    is_dynamic = False
 
-    def get_params(self):
-        return {
-            "updated_after": self.get_bookmark(),
-            "sort_by": "updated_at",
-            "sort_order": "ascending",
-        }
+    is_dynamic = False
 
 
 STREAM_OBJECTS = {

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -71,6 +71,25 @@ class Stream:
             yield rec
 
 
+class FullTableReplicationStream(Stream):
+    replication_keys = ["id"]
+    replication_method = "FULL_TABLE"
+
+    def get_default_start(self):
+        return 0
+
+    def post_sync_update_bookmark(self, *args, **kwargs):
+        self.update_bookmark(0)
+
+    def get_params(self):
+        return {
+            "created_after": self.config["start_date"],
+            "id_greater_than": self.get_bookmark(),
+            "sort_by": "id",
+            "sort_order": "ascending",
+        }
+
+
 class IdReplicationStream(Stream):
     replication_keys = ["id"]
     replication_method = "INCREMENTAL"
@@ -183,7 +202,7 @@ class Prospects(UpdatedAtReplicationStream):
     is_dynamic = False
 
 
-class Opportunities(UpdatedAtReplicationStream):
+class Opportunities(FullTableReplicationStream):
     stream_name = "opportunities"
     data_key = "opportunity"
     endpoint = "opportunity"
@@ -191,7 +210,7 @@ class Opportunities(UpdatedAtReplicationStream):
     is_dynamic = False
 
 
-class Users(UpdatedAtReplicationStream):
+class Users(FullTableReplicationStream):
     stream_name = "users"
     data_key = "user"
     endpoint = "user"

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -307,6 +307,14 @@ class Users(NoUpdatedAtSortingStream):
     is_dynamic = False
 
 
+class ListMemberships(NoUpdatedAtSortingStream):
+    stream_name = "list_memberships"
+    data_key = "list_membership"
+    endpoint = "listMembership"
+
+    is_dynamic = False
+
+
 class Campaigns(UpdatedAtSortByIdReplicationStream):
     stream_name = "campaigns"
     data_key = "campaign"

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -307,6 +307,14 @@ class Users(NoUpdatedAtSortingStream):
     is_dynamic = False
 
 
+class Visitors(UpdatedAtReplicationStream):
+    stream_name = "visitors"
+    data_key = "visitor"
+    endpoint = "visitor"
+
+    is_dynamic = False
+
+
 class Lists(UpdatedAtReplicationStream):
     stream_name = "lists"
     data_key = "list"

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -263,6 +263,71 @@ class UpdatedAtSortByIdReplicationStream(ComplexBookmarkStream):
             yield rec
 
 
+class ChildStream(ComplexBookmarkStream):
+    parent_class = None
+    parent_id_param = None
+
+    def pre_sync(self):
+        self.parent_bookmark = self.get_bookmark("parent_bookmark")
+
+        if self.parent_bookmark is None:
+            self.parent_bookmark = {}
+            self.update_bookmark("parent_bookmark", self.parent_bookmark)
+
+    def post_sync(self):
+        self.clear_bookmark("parent_bookmark")
+
+    def get_params(self):
+        return {"offset": self.get_bookmark("offset") or 0}
+
+    def get_records(self, parent_ids):
+        params = {self.parent_id_param: parent_ids, **self.get_params()}
+        data = self.client.post(self.endpoint, **params)
+        self.update_bookmark("offset", params["offset"] + 200)
+
+        if data["result"] is None or data["result"].get("total_results") == 0:
+            return []
+
+        records = data["result"][self.data_key]
+        if isinstance(records, dict):
+            records = [records]
+
+        return records
+
+    def sync_page(self, parent_ids):
+        for rec in self.get_records(parent_ids):
+            yield rec
+
+    def get_parent_ids(self, parent):
+        while True:
+            parent_ids = [rec["id"] for rec in parent.sync_page()]
+            if len(parent_ids):
+                yield parent_ids
+                self.update_bookmark("parent_bookmark", self.parent_bookmark)
+            else:
+                break
+
+    def sync(self):
+        self.pre_sync()
+
+        parent = self.parent_class(
+            self.client, self.config, self.parent_bookmark, emit=False
+        )
+
+        for parent_ids in self.get_parent_ids(parent):
+            records_synced = 0
+            last_records_synced = -1
+
+            while records_synced != last_records_synced:
+                last_records_synced = records_synced
+                for rec in self.sync_page(parent_ids):
+                    records_synced += 1
+                    yield rec
+            self.clear_bookmark("offset")
+
+        self.post_sync()
+
+
 class EmailClicks(IdReplicationStream):
     stream_name = "email_clicks"
     data_key = "emailClick"
@@ -317,6 +382,17 @@ class Visitors(UpdatedAtReplicationStream):
     endpoint = "visitor"
 
     is_dynamic = False
+
+
+class Visits(ChildStream):
+    stream_name = "visits"
+    data_key = "visit"
+    endpoint = "visit"
+
+    is_dynamic = False
+
+    parent_class = Visitors
+    parent_id_param = "visitor_ids"
 
 
 class Lists(UpdatedAtReplicationStream):

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -204,7 +204,7 @@ class NoUpdatedAtSortingStream(ComplexBookmarkStream):
         for rec in self.get_records():
             current_id = rec["id"]
 
-            if rec["updated_at"] < last_updated_at:
+            if rec["updated_at"] <= last_updated_at:
                 continue
 
             self.check_order(current_id)
@@ -414,7 +414,7 @@ class Visits(ChildStream, NoUpdatedAtSortingStream):
         self.max_updated_at = last_updated_at
 
         for rec in self.get_records(parent_ids):
-            if rec["updated_at"] < last_updated_at:
+            if rec["updated_at"] <= last_updated_at:
                 continue
             self.fix_page_views(rec)
             self.max_updated_at = max(self.max_updated_at, rec["updated_at"])
@@ -474,7 +474,7 @@ class ListMemberships(ChildStream, NoUpdatedAtSortingStream):
         self.max_updated_at = last_updated_at
 
         for rec in self.get_records(parent_id):
-            if rec["updated_at"] < last_updated_at:
+            if rec["updated_at"] <= last_updated_at:
                 continue
             self.max_updated_at = max(self.max_updated_at, rec["updated_at"])
             self.update_bookmark("id", rec["id"])

--- a/tap_pardot/sync.py
+++ b/tap_pardot/sync.py
@@ -6,21 +6,6 @@ from .streams import STREAM_OBJECTS
 LOGGER = singer.get_logger()
 
 
-def sync_page(stream_id, stream_object, transformer, catalog_entry):
-    records_synced = 0
-    for rec in stream_object.sync():
-        singer.write_record(
-            stream_id,
-            transformer.transform(
-                rec,
-                catalog_entry.schema.to_dict(),
-                metadata.to_map(catalog_entry.metadata),
-            ),
-        )
-        records_synced += 1
-    return bool(records_synced)
-
-
 def sync(client, config, state, catalog):
     selected_streams = catalog.get_selected_streams(state)
 
@@ -40,14 +25,12 @@ def sync(client, config, state, catalog):
         )
 
         LOGGER.info("Syncing stream: " + stream_id)
-        records_synced = True
-
-        start = utils.strftime(utils.now())
 
         with Transformer() as transformer:
-            while records_synced:
-                records_synced = sync_page(
-                    stream_id, stream_object, transformer, stream
+            for rec in stream_object.sync():
+                singer.write_record(
+                    stream_id,
+                    transformer.transform(
+                        rec, stream.schema.to_dict(), metadata.to_map(stream.metadata),
+                    ),
                 )
-
-            stream_object.post_sync_update_bookmark(start_time=start)

--- a/tap_pardot/sync.py
+++ b/tap_pardot/sync.py
@@ -1,18 +1,25 @@
 import singer
-from singer import metadata
-from singer import Transformer
+from singer import Transformer, metadata
+
 from .streams import STREAM_OBJECTS
 
 LOGGER = singer.get_logger()
 
+
 def sync_page(stream_id, stream_object, transformer, catalog_entry):
     records_synced = 0
     for rec in stream_object.sync():
-        singer.write_record(stream_id, transformer.transform(rec,
-                                                             catalog_entry.schema.to_dict(),
-                                                             metadata.to_map(catalog_entry.metadata)))
+        singer.write_record(
+            stream_id,
+            transformer.transform(
+                rec,
+                catalog_entry.schema.to_dict(),
+                metadata.to_map(catalog_entry.metadata),
+            ),
+        )
         records_synced += 1
     return bool(records_synced)
+
 
 def sync(client, config, state, catalog):
     selected_streams = catalog.get_selected_streams(state)
@@ -25,11 +32,18 @@ def sync(client, config, state, catalog):
         if stream_object is None:
             raise Exception("Attempted to sync unknown stream {}".format(stream_id))
 
-        singer.write_schema(stream_id, stream_schema.to_dict(), stream_object.key_properties, stream_object.replication_keys)
+        singer.write_schema(
+            stream_id,
+            stream_schema.to_dict(),
+            stream_object.key_properties,
+            stream_object.replication_keys,
+        )
         LOGGER.info("Starting discovery mode")
-        LOGGER.info('Syncing stream: ' + stream_id)
+        LOGGER.info("Syncing stream: " + stream_id)
         records_synced = True
         with Transformer() as transformer:
             while records_synced:
-                records_synced = sync_page(stream_id, stream_object, transformer, stream)
+                records_synced = sync_page(
+                    stream_id, stream_object, transformer, stream
+                )
     return

--- a/tap_pardot/sync.py
+++ b/tap_pardot/sync.py
@@ -38,7 +38,7 @@ def sync(client, config, state, catalog):
             stream_object.key_properties,
             stream_object.replication_keys,
         )
-        LOGGER.info("Starting discovery mode")
+
         LOGGER.info("Syncing stream: " + stream_id)
         records_synced = True
         with Transformer() as transformer:

--- a/tap_pardot/sync.py
+++ b/tap_pardot/sync.py
@@ -1,5 +1,5 @@
 import singer
-from singer import Transformer, metadata
+from singer import Transformer, metadata, utils
 
 from .streams import STREAM_OBJECTS
 
@@ -41,9 +41,13 @@ def sync(client, config, state, catalog):
 
         LOGGER.info("Syncing stream: " + stream_id)
         records_synced = True
+
+        start = utils.strftime(utils.now())
+
         with Transformer() as transformer:
             while records_synced:
                 records_synced = sync_page(
                     stream_id, stream_object, transformer, stream
                 )
-    return
+
+            stream_object.post_sync_update_bookmark(start_time=start)


### PR DESCRIPTION
# Description of change

Add Visits, Visitors, Lists, ListMemberships, Campaigns, Users, Opportunities, and Prospects streams.

This includes a variety of other changes to accommodate these streams, including:

- Moving all sync logic into the Stream object
- Creating a variety of abstract Stream classes for different sync mechanisms
- Moving the API endpoint into a property on the Stream object (decreases necessary changes when adding a new Stream)
- Automate the creation of STREAM_OBJECTS by finding Stream classes with a `stream_name` (decreases necessary changes when adding a new Stream)

# Manual QA steps

```
tap-pardot -c config.json --discover >! catalog.json
# enable some/all streams in catalog.json
tap-pardot -c config.json --catalog catalog.json
```

# Risks
- Some Streams, like Users, Opportunities, Visits, and ListMemberships require pulling all records for each sync. Since each API call can only return 200 results, it's possible that sync'ing these streams might make too many requests to the API thus causing it to reach its limits.
- The Visits stream is a child of Visitors. In order to sync, it first needs to fetch all Visitors that were updated since last time, and then fetch all the visits for those Visitors. This could again make too many calls.
- The ListMemberships stream seems to time out occasionally by using a normal sync strategy, so it might need to be treated as a child stream, causing similar issues as described above.
 
# Rollback steps
 - revert this branch
