### PR TITLE
Fix/visitor activity 504

### DIFF
--- a/tap_pardot/client.py
+++ b/tap_pardot/client.py
@@ -37,6 +37,7 @@ class Client:
     creds = None
 
     get_url = "{}/version/{}/do/query"
+    get_id_url = "{}/version/{}/do/read/id/{}"
     describe_url = "{}/version/{}/do/describe"
 
     def __init__(self, creds):
@@ -144,11 +145,14 @@ class Client:
         giveup=is_not_retryable_pardot_exception,
         jitter=None,
     )
-    def _fetch(self, method, endpoint, format_params, **kwargs):
+    def _fetch(self, method, endpoint, format_params, object_id=None, **kwargs):
         base_formatting = [endpoint, self.api_version]
         if format_params:
             base_formatting.extend(format_params)
-        url = (ENDPOINT_BASE + self.get_url).format(*base_formatting)
+        if object_id is not None:
+            url = (ENDPOINT_BASE + self.get_id_url).format(*base_formatting, object_id)
+        else:
+            url = (ENDPOINT_BASE + self.get_url).format(*base_formatting)
 
         params = {"format": "json", "output": "bulk", **kwargs}
 
@@ -160,6 +164,9 @@ class Client:
 
     def get(self, endpoint, format_params=None, **kwargs):
         return self._fetch("get", endpoint, format_params, **kwargs)
+
+    def get_specific(self, endpoint, object_id, format_params=None, **kwargs):
+        return self._fetch("get", endpoint, format_params, object_id, **kwargs)
 
     def post(self, endpoint, format_params=None, **kwargs):
         return self._fetch("post", endpoint, format_params, **kwargs)

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -218,6 +218,10 @@ class UpdatedAtDescendingSortReplicationStream(Stream):
 
     def get_records(self, window_start, window_end):
         """ Make one page request and update bookmarks, sync handles pagination based on result size. """
+        if window_start > window_end:
+            # Stop iteration scenario
+            return []
+
         replication_key = self.replication_key[0]
         sub_window_end = window_end
         data = self.client.get(self.endpoint, **self.get_params(window_start, window_end))

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -237,7 +237,10 @@ class UpdatedAtDescendingSortReplicationStream(Stream):
             records = [records]
 
         for rec in records:
-            self.check_order(rec[replication_key])
+            bookmark_value = rec.get(replication_key)
+            if bookmark_value is None:
+                raise Exception("visitor_activities - Visitor Activity (ID: {}) is missing updated_at value.".format(rec.get("id")))
+            self.check_order()
             yield rec
 
         sub_window_end = records[-1][replication_key]

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -240,7 +240,7 @@ class UpdatedAtDescendingSortReplicationStream(Stream):
             bookmark_value = rec.get(replication_key)
             if bookmark_value is None:
                 raise Exception("visitor_activities - Visitor Activity (ID: {}) is missing updated_at value.".format(rec.get("id")))
-            self.check_order()
+            self.check_order(bookmark_value)
             yield rec
 
         sub_window_end = records[-1][replication_key]

--- a/tap_pardot/sync.py
+++ b/tap_pardot/sync.py
@@ -15,9 +15,9 @@ def translate_state(client, state, selected_streams):
         if bookmark_id:
             bookmark_activity = client.get_specific("visitorActivity", bookmark_id)
             if bookmark_activity.get('visitor_activity', {}).get('updated_at'):
-                new_bookmark = utils.strftime(utils.strptime_to_utc(bookmark_activity['visitor_activity']['updated_at']))
+                new_bookmark = bookmark_activity['visitor_activity']['updated_at']
                 singer.bookmarks.clear_bookmark(state, "visitor_activities", "id")
-                singer.bookmarks.write_bookmark(state, "visitor_activities", "window_start", bookmark_activity['updated_at'])
+                singer.bookmarks.write_bookmark(state, "visitor_activities", "window_start", new_bookmark)
             else:
                 raise Exception("Could not translate state for visitor_activites, bookmarked activity is missing `updated_at` value")
 

--- a/tap_pardot/sync.py
+++ b/tap_pardot/sync.py
@@ -11,18 +11,18 @@ def translate_state(client, state, selected_streams):
     """
     selected_stream_names = [s.tap_stream_id for s in selected_streams]
     if "visitor_activities" in selected_stream_names:
-        bookmark_id = singer.bookmark.get_bookmark(state, "visitor_activities", "id")
+        bookmark_id = singer.bookmarks.get_bookmark(state, "visitor_activities", "id")
         if bookmark_id:
             bookmark_activity = client.get_specific("visitorActivity", bookmark_id)
             if bookmark_activity.get('visitor_activity', {}).get('updated_at'):
                 new_bookmark = utils.strftime(utils.strptime_to_utc(bookmark_activity['visitor_activity']['updated_at']))
-                singer.bookmark.clear_bookmark(state, "visitor_activities", "id")
-                singer.bookmark.write_bookmark(state, "visitor_activities", "window_start", bookmark_activity['updated_at'])
+                singer.bookmarks.clear_bookmark(state, "visitor_activities", "id")
+                singer.bookmarks.write_bookmark(state, "visitor_activities", "window_start", bookmark_activity['updated_at'])
             else:
                 raise Exception("Could not translate state for visitor_activites, bookmarked activity is missing `updated_at` value")
 
 def sync(client, config, state, catalog):
-    selected_streams = catalog.get_selected_streams(state)
+    selected_streams = list(catalog.get_selected_streams(state))
     translate_state(client, state, selected_streams)
 
     for stream in selected_streams:

--- a/tap_pardot/sync.py
+++ b/tap_pardot/sync.py
@@ -5,9 +5,25 @@ from .streams import STREAM_OBJECTS
 
 LOGGER = singer.get_logger()
 
+def translate_state(client, state, selected_streams):
+    """
+    Translate the state for streams that have changed their patterns
+    """
+    selected_stream_names = [s.tap_stream_id for s in selected_streams]
+    if "visitor_activities" in selected_stream_names:
+        bookmark_id = singer.bookmark.get_bookmark(state, "visitor_activities", "id")
+        if bookmark_id:
+            bookmark_activity = client.get_specific("visitorActivity", bookmark_id)
+            if bookmark_activity.get('visitor_activity', {}).get('updated_at'):
+                new_bookmark = utils.strftime(utils.strptime_to_utc(bookmark_activity['visitor_activity']['updated_at']))
+                singer.bookmark.clear_bookmark(state, "visitor_activities", "id")
+                singer.bookmark.write_bookmark(state, "visitor_activities", "window_start", bookmark_activity['updated_at'])
+            else:
+                raise Exception("Could not translate state for visitor_activites, bookmarked activity is missing `updated_at` value")
 
 def sync(client, config, state, catalog):
     selected_streams = catalog.get_selected_streams(state)
+    translate_state(client, state, selected_streams)
 
     for stream in selected_streams:
         stream_id = stream.tap_stream_id


### PR DESCRIPTION
# Description of change
Pardot's API will return a 504 on large requests with certain parameters for the `visitorActivity` endpoint. There's an inactive topic on the Salesforce community boards that suggests changing the request parameters could cause this to be more efficient. https://trailblazers.salesforce.com/answers?id=9063A000000DlRUQA0

In testing, sorting by `updated_at` descending proved to be the only consistent option, so this PR adds a stream type to handle that pattern (bookmarking based on tap-trello's implementation).

This PR also adds a method to translate existing "id-based" state to the current "updated_at" based state, using a request for the activity object whose ID is bookmarked.

Of note: The API seems to treat datetimes formatted as `YYYY-mm-DD HH:MM:SS` as the user's time zone, and datetimes formatted as `YYYY-mm-DDTHH:MM:SSZ` as UTC. A critical part of this PR is to never change the formatting of values so that these types can be mixed effectively for consistency.

# Manual QA steps
 - Ran through cases of the state to confirm that:
    - The expected count of records is returned using this method
    - The pagination works and aligns using mixed datetime format (UTC vs user, in this case EDT)
    - The state translation works and successfully overrides a reasonable start_date (e.g., `2019-04-12T00:00:00.000000Z`)
 
# Risks
 - Medium, this is the replacement of an existing pattern, and testing will need to be performed end to end with a live connection to validate the resulting data.
 
# Rollback steps
 - revert this branch, bump patch version, and release
