### PR TITLE
Version bump to v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.4.0
+  * Alters Visitors stream to pull all visitors, not just "identified" visitors [#29](https://github.com/singer-io/tap-pardot/pull/29)
+
 ## 1.3.1
   * Changes error message [#24](https://github.com/singer-io/tap-pardot/pull/24)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-pardot",
-    version="1.3.1",
+    version="1.4.0",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",


### PR DESCRIPTION
# Description of change
## 1.4.0
  * Alters Visitors stream to pull all visitors, not just "identified" visitors [#29](https://github.com/singer-io/tap-pardot/pull/29)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
