### PR TITLE
Call join correctly

### DIFF
--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -440,7 +440,7 @@ class Visits(ChildStream, NoUpdatedAtSortingStream):
             self.max_updated_at = max(self.max_updated_at, rec["updated_at"])
             yield rec
     def format_parent_ids(self, parent_ids):
-        return ",".join(parent_ids)
+        return ",".join(str(parent_id) for parent_id in parent_ids)
 
 class Lists(UpdatedAtReplicationStream):
     stream_name = "lists"


### PR DESCRIPTION
# Description of change
This PR grabs another change from #15 to call `join()` with an iterable

# Manual QA steps

```python
>>> parent_ids = [1, 2]
>>> ",".join(str(parent_id) for parent_id in parent_ids)
'1,2'
>>> parent_ids = 1
>>> ",".join(str(parent_id) for parent_id in parent_ids)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'int' object is not iterable
``` 
 
# Risks
If `Visits` ever gets a singular `parent_id`, the tap will fail again

# Rollback steps
 - revert this branch
