### PR TITLE
version bump v1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.4.3
+  * Reverts back to v1.3.1 PR [#36](https://github.com/singer-io/tap-pardot/pull/36)
+
 ## 1.4.2
   * Attempts to fix previous PR [#34](https://github.com/singer-io/tap-pardot/pull/34)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-pardot",
-    version="1.4.2",
+    version="1.4.3",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",


### PR DESCRIPTION
# Description of change
## 1.4.3
  * Reverts back to v1.3.1 PR [#36](https://github.com/singer-io/tap-pardot/pull/36)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
