### PR TITLE
updated prospects stream sync function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,17 +24,6 @@ jobs:
             source /usr/local/share/virtualenvs/tap-pardot/bin/activate
             pylint tap_pardot -d C,R,W
       - run:
-          name: 'Unit Tests'
-          command: |
-            source /usr/local/share/virtualenvs/tap-pardot/bin/activate
-            pip install nose coverage
-            nosetests --with-coverage --cover-erase --cover-package=tap_pardot --cover-html-dir=htmlcov tests/unittests
-            coverage html
-      - store_test_results:
-          path: test_output/report.xml
-      - store_artifacts:
-          path: htmlcov
-      - run:
           name: 'Integration Tests'
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
             python3 -mvenv /usr/local/share/virtualenvs/tap-pardot
             source /usr/local/share/virtualenvs/tap-pardot/bin/activate
             pip install -U 'pip==22.2.2' 'setuptools==65.3.0'
+            pip install -U pylint
             pip install .[dev]
       - run:
           name: 'JSON Validator'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,61 @@
+version: 2.1
+jobs:
+  build:
+    docker:
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+    steps:
+      - checkout
+      - run:
+          name: 'Setup virtual env'
+          command: |
+            python3 -mvenv /usr/local/share/virtualenvs/tap-pardot
+            source /usr/local/share/virtualenvs/tap-pardot/bin/activate
+            pip install -U 'pip==22.2.2' 'setuptools==65.3.0'
+            pip install .[dev]
+      - run:
+          name: 'JSON Validator'
+          command: |
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            stitch-validate-json tap_pardot/schemas/*.json
+      - run:
+          name: 'pylint'
+          command: |
+            source /usr/local/share/virtualenvs/tap-pardot/bin/activate
+            pylint tap_pardot -d C,R,W
+      - run:
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-pardot/bin/activate
+            pip install nose coverage
+            nosetests --with-coverage --cover-erase --cover-package=tap_pardot --cover-html-dir=htmlcov tests/unittests
+            coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
+      - run:
+          name: 'Integration Tests'
+          command: |
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
+            source dev_env.sh
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            run-test --tap=tap-pardot tests
+
+
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - build:
+          context: circleci-user
+  build_daily:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build:
+          context: circleci-user

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.4.5
+  * Prospects Stream Fix Pagination [#42](https://github.com/singer-io/tap-pardot/pull/42)
+
 ## 1.4.4
   * Dependabot update [#41](https://github.com/singer-io/tap-pardot/pull/41)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-pardot",
-    version="1.4.4",
+    version="1.4.5",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -376,6 +376,27 @@ class Prospects(UpdatedAtReplicationStream):
 
     is_dynamic = False
 
+    def get_records(self):
+        offset = 0
+        params = self.get_params()
+        while True:
+            params["offset"] = offset
+            data = self.client.get(self.endpoint, **params)
+            records = data["result"]
+            if not records:
+                break
+            offset += 200
+            yield from records[self.data_key]
+        return
+
+    def sync(self):
+        # temp: removed the orignal sync implementation
+        # as facing issue with duplicate records
+        self.pre_sync()
+        for rec in self.sync_page():
+            yield rec
+        self.post_sync()
+
 
 class Opportunities(NoUpdatedAtSortingStream):
     stream_name = "opportunities"

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -326,7 +326,7 @@ class ChildStream(ComplexBookmarkStream):
 
     def sync(self):
         self.pre_sync()
-
+        # pylint: disable=E1102
         parent = self.parent_class(
             self.client, self.config, self.parent_bookmark, emit=False
         )

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -387,11 +387,8 @@ class Prospects(UpdatedAtReplicationStream):
                 break
             offset += 200
             yield from records[self.data_key]
-        return
 
     def sync(self):
-        # temp: removed the orignal sync implementation
-        # as facing issue with duplicate records
         self.pre_sync()
         for rec in self.sync_page():
             yield rec


### PR DESCRIPTION
# Description of change
- Fixes Data discrepancy for prospects stream (adds support for limit offset pagination) 

ref: https://developer.salesforce.com/docs/marketing/pardot/guide/prospects-v4.html#parameters-to-specify-which-results-are-returned

The default implementation would refer to the last record on the current page to get the next `updated_at` for the next request, this resulted in few records being missed in the iteration.


# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
