### PR TITLE
Fetch all visitors records and update request params type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.9
+  * Update Visitors stream to pull all visitors, not just "identified" visitors [53](https://github.com/singer-io/tap-pardot/pull/53)
+  * Pass comma separated visitor_ids to fetch visits.
+
 ## 1.4.8
   * Bump dependency versions for twistlock compliance [#48](https://github.com/singer-io/tap-pardot/pull/48)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-pardot",
-    version="1.4.8",
+    version="1.4.9",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -298,7 +298,7 @@ class ChildStream(ComplexBookmarkStream):
         return {"offset": self.get_bookmark("offset")}
 
     def get_records(self, parent_ids):
-        params = {self.parent_id_param: str(parent_ids), **self.get_params()}
+        params = {self.parent_id_param: self.format_parent_ids(parent_ids), **self.get_params()}
         data = self.client.post(self.endpoint, **params)
         self.update_bookmark("offset", params.get("offset", 0) + 200)
 
@@ -310,6 +310,9 @@ class ChildStream(ComplexBookmarkStream):
             records = [records]
 
         return records
+
+    def format_parent_ids(self, parent_ids):
+        return parent_ids
 
     def sync_page(self, parent_ids):
         for rec in self.get_records(parent_ids):
@@ -422,6 +425,9 @@ class Visits(ChildStream, NoUpdatedAtSortingStream):
         page_views = record["visitor_page_views"]["visitor_page_view"]
         if isinstance(page_views, dict):
             record["visitor_page_views"]["visitor_page_view"] = [page_views]
+
+    def format_parent_ids(self, parent_ids):
+        return ",".join(str(i) for i in parent_ids)
 
     def sync_page(self, parent_ids):
         """

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -310,7 +310,7 @@ class ChildStream(ComplexBookmarkStream):
         return records
 
 
-    def sync_page(self):
+    def sync_page(self, parent_ids):
         for rec in self.get_records():
             yield rec
 

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -281,6 +281,7 @@ class UpdatedAtSortByIdReplicationStream(ComplexBookmarkStream):
 class ChildStream(ComplexBookmarkStream):
     parent_class = None
     parent_id_param = None
+    parent_ids = None
 
     def pre_sync(self):
         self.parent_bookmark = self.get_bookmark("parent_bookmark")
@@ -294,11 +295,8 @@ class ChildStream(ComplexBookmarkStream):
         self.clear_bookmark("parent_bookmark")
         super(ChildStream, self).post_sync()
 
-    def get_params(self):
-        return {"offset": self.get_bookmark("offset")}
-
-    def get_records(self, parent_ids):
-        params = {self.parent_id_param: self.format_parent_ids(parent_ids), **self.get_params()}
+    def get_records(self):
+        params = self.get_params()
         data = self.client.post(self.endpoint, **params)
         self.update_bookmark("offset", params.get("offset", 0) + 200)
 
@@ -311,11 +309,9 @@ class ChildStream(ComplexBookmarkStream):
 
         return records
 
-    def format_parent_ids(self, parent_ids):
-        return parent_ids
 
-    def sync_page(self, parent_ids):
-        for rec in self.get_records(parent_ids):
+    def sync_page(self):
+        for rec in self.get_records():
             yield rec
 
     def get_parent_ids(self, parent):
@@ -426,8 +422,11 @@ class Visits(ChildStream, NoUpdatedAtSortingStream):
         if isinstance(page_views, dict):
             record["visitor_page_views"]["visitor_page_view"] = [page_views]
 
-    def format_parent_ids(self, parent_ids):
-        return ",".join(str(_id) for _id in parent_ids)
+    def get_params(self):
+        return {
+            "offset": self.get_bookmark("offset"),
+            self.parent_id_param: ",".join(str(_id) for _id in self.parent_ids)
+        }
 
     def sync_page(self, parent_ids):
         """
@@ -435,7 +434,8 @@ class Visits(ChildStream, NoUpdatedAtSortingStream):
 
         This is handled in ChildStream base class.
         """
-        for rec in self.get_records(parent_ids):
+        self.parent_ids = parent_ids
+        for rec in self.get_records():
             if rec["updated_at"] <= self.last_updated_at:
                 continue
             self.fix_page_views(rec)
@@ -475,6 +475,7 @@ class ListMemberships(ChildStream, NoUpdatedAtSortingStream):
             "id_greater_than": self.get_bookmark("id") or 0,
             "sort_by": "id",
             "sort_order": "ascending",
+            self.parent_id_param: self.parent_ids
         }
 
     def get_parent_ids(self, parent):
@@ -492,7 +493,8 @@ class ListMemberships(ChildStream, NoUpdatedAtSortingStream):
     def sync_page(self, parent_id):
         """ListMemberships use id to paginate through, so we override ChildStream
         behavior."""
-        for rec in self.get_records(parent_id):
+        self.parent_ids = parent_id
+        for rec in self.get_records():
             if rec["updated_at"] <= self.last_updated_at:
                 continue
             self.max_updated_at = max(self.max_updated_at, rec["updated_at"])

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -400,6 +400,13 @@ class Visitors(UpdatedAtReplicationStream):
 
     is_dynamic = False
 
+    def get_params(self):
+        return {
+            "updated_after": self.get_bookmark(),
+            "sort_by": "updated_at",
+            "sort_order": "ascending",
+            "only_identified":"false"
+        }
 
 class Visits(ChildStream, NoUpdatedAtSortingStream):
     stream_name = "visits"

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -298,7 +298,7 @@ class ChildStream(ComplexBookmarkStream):
         return {"offset": self.get_bookmark("offset")}
 
     def get_records(self, parent_ids):
-        params = {self.parent_id_param: parent_ids, **self.get_params()}
+        params = {self.parent_id_param: str(parent_ids), **self.get_params()}
         data = self.client.post(self.endpoint, **params)
         self.update_bookmark("offset", params.get("offset", 0) + 200)
 

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -408,7 +408,7 @@ class Visitors(UpdatedAtReplicationStream):
             "updated_after": self.get_bookmark(),
             "sort_by": "updated_at",
             "sort_order": "ascending",
-            "only_identified":"false"
+            "only_identified": "false"
         }
 
 class Visits(ChildStream, NoUpdatedAtSortingStream):
@@ -427,7 +427,7 @@ class Visits(ChildStream, NoUpdatedAtSortingStream):
             record["visitor_page_views"]["visitor_page_view"] = [page_views]
 
     def format_parent_ids(self, parent_ids):
-        return ",".join(str(i) for i in parent_ids)
+        return ",".join(str(_id) for _id in parent_ids)
 
     def sync_page(self, parent_ids):
         """


### PR DESCRIPTION
# Description of change
Reg: [SUPPORT-3914](https://qlik-dev.atlassian.net/browse/SUPPORT-3914)

Customer is missing visits records due to below reasons,
- The api only fetches Request visitors that have an identified company by default, due to which the customer was missing this data. We have disabled the flag to extract all visitors,
- We pass params in request function of requests and it returns only single record per request for visits stream. However, when the query string is manually built and appended to the URL, the API returns all expected records. This appears to be a quirk in how the Pardot API handles list parameters when passed through requests. So, passing list as str.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
