### PR TITLE
Added implementation to exclude unauthorized streams from discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
+
 ## 2.1.0
   * Exclude unauthorized (403) streams from the discovery catalog [#57](https://github.com/singer-io/tap-pardot/pull/57)
+  * Added `parent-tap-stream-id` metadata, Updated Integration Tests [#54](https://github.com/singer-io/tap-pardot/pull/54)
 
 ## 2.0.0
   * Upgrade Python from 3.9 to 3.12 [#56](https://github.com/singer-io/tap-pardot/pull/56)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
 # Changelog
 
 ## 2.1.0
-  * Streams the credentials cannot access (403) are now excluded from the catalog during discovery instead of raising an error.
-  * Child streams are automatically excluded when their parent stream is inaccessible.
-  * Added unit tests for discovery access checks.
+  * Exclude Streams that the credentials cannot access (403) from the catalog during discovery; discovery fails only if the credentials cannot read any supported parent stream.[#57](https://github.com/singer-io/tap-pardot/pull/57)
 
 ## 2.0.0
   * Upgrade Python from 3.9 to 3.12 [#56](https://github.com/singer-io/tap-pardot/pull/56)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.1.0
-  * Exclude Streams that the credentials cannot access (403) from the catalog during discovery; discovery fails only if the credentials cannot read any supported parent stream. [#57](https://github.com/singer-io/tap-pardot/pull/57)
+  * Exclude unauthorized (403) streams from the discovery catalog [#57](https://github.com/singer-io/tap-pardot/pull/57)
 
 ## 2.0.0
   * Upgrade Python from 3.9 to 3.12 [#56](https://github.com/singer-io/tap-pardot/pull/56)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.0
+  * Streams the credentials cannot access (403) are now excluded from the catalog during discovery instead of raising an error.
+  * Child streams are automatically excluded when their parent stream is inaccessible.
+  * Added unit tests for discovery access checks.
+
 ## 2.0.0
   * Upgrade Python from 3.9 to 3.12 [#56](https://github.com/singer-io/tap-pardot/pull/56)
   * Add unit and integration tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.1.0
-  * Exclude Streams that the credentials cannot access (403) from the catalog during discovery; discovery fails only if the credentials cannot read any supported parent stream.[#57](https://github.com/singer-io/tap-pardot/pull/57)
+  * Exclude Streams that the credentials cannot access (403) from the catalog during discovery; discovery fails only if the credentials cannot read any supported parent stream. [#57](https://github.com/singer-io/tap-pardot/pull/57)
 
 ## 2.0.0
   * Upgrade Python from 3.9 to 3.12 [#56](https://github.com/singer-io/tap-pardot/pull/56)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-pardot",
-    version="2.0.0",
+    version="2.1.0",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_pardot/client.py
+++ b/tap_pardot/client.py
@@ -20,6 +20,9 @@ class Pardot401Error(Exception):
 class Pardot89Error(Exception):
     pass
 
+class PardotForbiddenError(Exception):
+    pass
+
 class AuthCredsMissingError(Exception):
     def __init__(self, message):
         super().__init__(message)
@@ -183,6 +186,12 @@ class Client:
                 LOGGER.warning("Received a 401 unauthenticated error from Pardot. Reauthing and retrying the request.")
                 self.refresh_credentials()
                 raise Pardot401Error
+
+        # 403 errors indicate the credentials lack access
+        if response.status_code == 403:
+            raise PardotForbiddenError(
+                "HTTP-error-code: 403, Error: Insufficient permissions to access this resource."
+            )
 
         # 5xx errors should be retried
         if response.status_code >= 500:

--- a/tap_pardot/client.py
+++ b/tap_pardot/client.py
@@ -194,7 +194,7 @@ class Client:
         if response.status_code == 403:
             error_detail = response.text[:200] if response.text else "No additional details"
             raise PardotForbiddenError(
-                f"HTTP 403 Forbidden for endpoint {full_url}: {error_detail}"
+                f"URL: {full_url}, HTTP-Error-Code: 403, HTTP-Error-Message: {error_detail}"
             )
 
         # 5xx errors should be retried

--- a/tap_pardot/client.py
+++ b/tap_pardot/client.py
@@ -192,8 +192,9 @@ class Client:
 
         # 403 errors indicate the credentials lack access
         if response.status_code == 403:
+            error_detail = response.text[:200] if response.text else "No additional details"
             raise PardotForbiddenError(
-                "HTTP-error-code: 403, Error: Insufficient permissions to access this resource."
+                f"HTTP 403 Forbidden for endpoint {full_url}: {error_detail}"
             )
 
         # 5xx errors should be retried

--- a/tap_pardot/client.py
+++ b/tap_pardot/client.py
@@ -142,20 +142,23 @@ class Client:
             "Content-Type": "application/x-www-form-urlencoded"
         }
 
-        params = {
+        data = {
             "grant_type": "refresh_token",
             "refresh_token": self.creds["refresh_token"],
         }
-        method = "POST"
 
-        response = requests.request(
-            method,
+        response = requests.post(
             REFRESH_URL,
             headers=headers,
-            params=params
+            data=data,
+            timeout=30,
         )
 
-        response.raise_for_status()
+        if response.status_code != 200:
+            raise Exception(
+                f"OAuth token refresh failed with status {response.status_code}. "
+                "Verify that refresh_token, client_id, and client_secret are valid."
+            )
         response = response.json()
 
         self.creds['access_token'] = response["access_token"]

--- a/tap_pardot/discover.py
+++ b/tap_pardot/discover.py
@@ -99,7 +99,7 @@ def _apply_access_checks(client, schemas):
         )
     if inaccessible_streams:
         LOGGER.warning(
-            "These streams have been excluded due to 403 Forbidden: %s",
+            "These streams have been excluded due to HTTP-Error-Code:403 Forbidden: %s",
             ", ".join(inaccessible_streams),
         )
 

--- a/tap_pardot/discover.py
+++ b/tap_pardot/discover.py
@@ -40,26 +40,31 @@ def _load_schemas(client):
     for stream in schemas.keys():
         stream_object = STREAM_OBJECTS[stream]
         if stream_object.is_dynamic:
-            # Client describe
-            schema_response = client.describe(stream_object.endpoint)
-            # Parse Result into JSON Schema
-            dynamic_schema_parts = _parse_schema_description(schema_response)
-            # Add to schemas
-            schemas[stream] = {
-                "type": "object",
-                "properties": {**schemas[stream]["properties"], **dynamic_schema_parts},
-            }
+            try:
+                # Client describe
+                schema_response = client.describe(stream_object.endpoint)
+                # Parse Result into JSON Schema
+                dynamic_schema_parts = _parse_schema_description(schema_response)
+                # Add to schemas
+                schemas[stream] = {
+                    "type": "object",
+                    "properties": {**schemas[stream]["properties"], **dynamic_schema_parts},
+                }
+            except PardotForbiddenError:
+                LOGGER.warning(
+                    "Stream '%s' describe endpoint returned 403, skipping dynamic schema merge.",
+                    stream,
+                )
 
     return schemas
 
 
 def _apply_access_checks(client, schemas):
     """
-    Probe each stream for read access and remove inaccessible streams from schemas in place.
-    Logic:
-      1. Check all parent streams first; remove inaccessible ones.
-      2. Prune children whose parent was removed (no need to check them individually).
-      3. Check remaining child streams individually; remove inaccessible ones.
+    Probe each parent stream for read access and remove inaccessible streams
+    (and their children) from schemas in place.
+    Child streams are not checked individually — their access is governed by
+    the parent stream check.
     Raises PardotForbiddenError if no parent streams are accessible.
     """
     dummy_config = {"start_date": "2100-01-01T00:00:00Z"}
@@ -67,12 +72,12 @@ def _apply_access_checks(client, schemas):
 
     inaccessible_streams = []
 
-    # Step 1: Check parent streams
+    # Check only parent streams for access
     for stream_name in list(schemas.keys()):
         stream_cls = STREAM_OBJECTS.get(stream_name)
         if stream_cls is None:
             continue
-        # Only check parent streams in this pass
+        # Skip child streams — access governed by parent
         if hasattr(stream_cls, 'parent_class') and stream_cls.parent_class is not None:
             continue
         stream_obj = stream_cls(client=client, config=dummy_config, state=dummy_state, emit=False)
@@ -82,21 +87,8 @@ def _apply_access_checks(client, schemas):
     for stream_name in inaccessible_streams:
         schemas.pop(stream_name, None)
 
-    # Step 2: Prune children of inaccessible parents
+    # Prune children of inaccessible parents
     _prune_inaccessible_children(schemas)
-
-    # Step 3: Check remaining child streams individually
-    for stream_name in list(schemas.keys()):
-        stream_cls = STREAM_OBJECTS.get(stream_name)
-        if stream_cls is None:
-            continue
-        # Only check child streams in this pass
-        if not (hasattr(stream_cls, 'parent_class') and stream_cls.parent_class is not None):
-            continue
-        stream_obj = stream_cls(client=client, config=dummy_config, state=dummy_state, emit=False)
-        if not stream_obj.check_access():
-            inaccessible_streams.append(stream_name)
-            schemas.pop(stream_name, None)
 
     if inaccessible_streams:
         # Check if ALL parent streams are inaccessible

--- a/tap_pardot/discover.py
+++ b/tap_pardot/discover.py
@@ -95,7 +95,7 @@ def _apply_access_checks(client, schemas):
 
     if not schemas:
         raise PardotForbiddenError(
-            "All streams returned 403. Verify that the credentials have read access to at least one stream."
+            "No streams are accessible. Ensure the credentials have read permission for at least one stream."
         )
     if inaccessible_streams:
         LOGGER.warning(

--- a/tap_pardot/discover.py
+++ b/tap_pardot/discover.py
@@ -139,12 +139,19 @@ def discover(client):
     for stream_name, schema in raw_schemas.items():
         # create and add catalog entry
         stream = STREAM_OBJECTS[stream_name]
+
         mdata = metadata.get_standard_metadata(
-            schema=schema,
-            key_properties=stream.key_properties,
-            valid_replication_keys=stream.replication_keys,
-            replication_method=stream.replication_method,
+                schema=schema,
+                key_properties=stream.key_properties,
+                valid_replication_keys=stream.replication_keys,
+                replication_method=stream.replication_method,
         )
+
+        if hasattr(stream, 'parent_class') and stream.parent_class is not None:
+            mdata = metadata.to_map(mdata)
+            mdata = metadata.write(mdata, (), "parent-tap-stream-id", stream.parent_class.stream_name)
+            mdata = metadata.to_list(mdata)
+
         # Mark replication keys as automatic inclusion
         mdata_map = metadata.to_map(mdata)
         for rep_key in (stream.replication_keys or []):

--- a/tap_pardot/discover.py
+++ b/tap_pardot/discover.py
@@ -4,6 +4,7 @@ import os
 import singer
 from singer import Catalog, metadata
 
+from .client import PardotForbiddenError
 from .streams import STREAM_OBJECTS
 
 LOGGER = singer.get_logger()
@@ -52,9 +53,95 @@ def _load_schemas(client):
     return schemas
 
 
+def _apply_access_checks(client, schemas):
+    """
+    Probe each stream for read access and remove inaccessible streams from schemas in place.
+    Logic:
+      1. Check all parent streams first; remove inaccessible ones.
+      2. Prune children whose parent was removed (no need to check them individually).
+      3. Check remaining child streams individually; remove inaccessible ones.
+    Raises PardotForbiddenError if no parent streams are accessible.
+    """
+    dummy_config = {"start_date": "2100-01-01T00:00:00Z"}
+    dummy_state = {}
+
+    inaccessible_streams = []
+
+    # Step 1: Check parent streams
+    for stream_name in list(schemas.keys()):
+        stream_cls = STREAM_OBJECTS.get(stream_name)
+        if stream_cls is None:
+            continue
+        # Only check parent streams in this pass
+        if hasattr(stream_cls, 'parent_class') and stream_cls.parent_class is not None:
+            continue
+        stream_obj = stream_cls(client=client, config=dummy_config, state=dummy_state, emit=False)
+        if not stream_obj.check_access():
+            inaccessible_streams.append(stream_name)
+
+    for stream_name in inaccessible_streams:
+        schemas.pop(stream_name, None)
+
+    # Step 2: Prune children of inaccessible parents
+    _prune_inaccessible_children(schemas)
+
+    # Step 3: Check remaining child streams individually
+    for stream_name in list(schemas.keys()):
+        stream_cls = STREAM_OBJECTS.get(stream_name)
+        if stream_cls is None:
+            continue
+        # Only check child streams in this pass
+        if not (hasattr(stream_cls, 'parent_class') and stream_cls.parent_class is not None):
+            continue
+        stream_obj = stream_cls(client=client, config=dummy_config, state=dummy_state, emit=False)
+        if not stream_obj.check_access():
+            inaccessible_streams.append(stream_name)
+            schemas.pop(stream_name, None)
+
+    if inaccessible_streams:
+        # Check if ALL parent streams are inaccessible
+        total_parent_streams = len([
+            name for name, cls in STREAM_OBJECTS.items()
+            if not (hasattr(cls, 'parent_class') and cls.parent_class is not None)
+        ])
+        inaccessible_parent_count = len([
+            name for name in inaccessible_streams
+            if not (hasattr(STREAM_OBJECTS[name], 'parent_class') and STREAM_OBJECTS[name].parent_class is not None)
+        ])
+        if inaccessible_parent_count == total_parent_streams:
+            raise PardotForbiddenError(
+                "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "
+                "of the streams supported by the tap. Data collection cannot be initiated due to lack of permissions."
+            )
+        LOGGER.warning(
+            "The account credentials supplied do not have 'read' access to the following stream(s): %s. "
+            "These streams have been excluded from the catalog.",
+            ", ".join(inaccessible_streams),
+        )
+
+
+def _prune_inaccessible_children(schemas):
+    """
+    Remove child streams from the catalog whose parent stream was excluded.
+    Mutates schemas in place.
+    """
+    for name, stream_cls in list(STREAM_OBJECTS.items()):
+        if name in schemas and hasattr(stream_cls, 'parent_class') and stream_cls.parent_class:
+            parent_stream_name = stream_cls.parent_class.stream_name
+            if parent_stream_name not in schemas:
+                LOGGER.warning(
+                    "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
+                    name, parent_stream_name,
+                )
+                schemas.pop(name)
+
+
 def discover(client):
     LOGGER.info("Starting discovery mode")
     raw_schemas = _load_schemas(client)
+
+    _apply_access_checks(client, raw_schemas)
+
     streams = []
 
     for stream_name, schema in raw_schemas.items():

--- a/tap_pardot/discover.py
+++ b/tap_pardot/discover.py
@@ -4,6 +4,8 @@ import os
 import singer
 from singer import Catalog, metadata
 
+from datetime import datetime, timezone
+
 from .client import PardotForbiddenError
 from .streams import STREAM_OBJECTS
 
@@ -67,10 +69,8 @@ def _apply_access_checks(client, schemas):
     the parent stream check.
     Raises PardotForbiddenError if no parent streams are accessible.
     """
-    dummy_config = {"start_date": "2100-01-01T00:00:00Z"}
-    dummy_state = {}
-
     inaccessible_streams = []
+    current_date = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     # Check only parent streams for access
     for stream_name in list(schemas.keys()):
@@ -80,7 +80,10 @@ def _apply_access_checks(client, schemas):
         # Skip child streams — access governed by parent
         if hasattr(stream_cls, 'parent_class') and stream_cls.parent_class is not None:
             continue
-        stream_obj = stream_cls(client=client, config=dummy_config, state=dummy_state, emit=False)
+        stream_obj = stream_cls(client=client,
+                                config={"start_date": current_date},
+                                state={},
+                                emit=False)
         if not stream_obj.check_access():
             inaccessible_streams.append(stream_name)
 
@@ -90,24 +93,13 @@ def _apply_access_checks(client, schemas):
     # Prune children of inaccessible parents
     _prune_inaccessible_children(schemas)
 
+    if not schemas:
+        raise PardotForbiddenError(
+            "All streams returned 403. Verify that the credentials have read access to at least one stream."
+        )
     if inaccessible_streams:
-        # Check if ALL parent streams are inaccessible
-        total_parent_streams = len([
-            name for name, cls in STREAM_OBJECTS.items()
-            if not (hasattr(cls, 'parent_class') and cls.parent_class is not None)
-        ])
-        inaccessible_parent_count = len([
-            name for name in inaccessible_streams
-            if not (hasattr(STREAM_OBJECTS[name], 'parent_class') and STREAM_OBJECTS[name].parent_class is not None)
-        ])
-        if inaccessible_parent_count == total_parent_streams:
-            raise PardotForbiddenError(
-                "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "
-                "of the streams supported by the tap. Data collection cannot be initiated due to lack of permissions."
-            )
         LOGGER.warning(
-            "The account credentials supplied do not have 'read' access to the following stream(s): %s. "
-            "These streams have been excluded from the catalog.",
+            "These streams have been excluded due to 403 Forbidden: %s",
             ", ".join(inaccessible_streams),
         )
 

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -74,7 +74,11 @@ class Stream:
         """
         Verify that the API credentials have read access to this stream.
         Returns True if accessible, False if a 403 Forbidden error is raised.
+        Child streams always return True (access is governed by the parent check).
         """
+        if self.is_child_stream():
+            return True
+
         try:
             self.client.get(self.endpoint, created_after="2100-01-01 00:00:00",
                            sort_by="id", sort_order="ascending")

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -89,10 +89,10 @@ class Stream:
             return True
         except PardotForbiddenError as exc:
             LOGGER.warning(
-                "Stream '%s' does not have read permission, excluding from catalog. Detail: %s",
-                self.stream_name,
-                str(exc),
-            )
+                    "Unauthorized Stream: %s, excluding '%s' from catalog.",
+                    str(exc),
+                    self.stream_name
+                )            
             return False
 
     def is_child_stream(self):

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -89,7 +89,7 @@ class Stream:
             return True
         except PardotForbiddenError as exc:
             LOGGER.warning(
-                "Unauthorized Stream: %s, excluding from catalog. HTTP ERROR '%s'",
+                "Unauthorized Stream: %s, excluding from catalog. HTTP-Error-Message:'%s'",
                 self.stream_name,
                 str(exc),
             )

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -79,9 +79,17 @@ class Stream:
         if self.is_child_stream():
             return True
 
+        # Use the stream's normal query params to avoid passing unsupported filters,
+        # but force the time filter into the future so we don't fetch real data.
+        params = dict(self.get_params() or {})
+        future_dt = "2100-01-01 00:00:00"
+        if "created_after" in params:
+            params["created_after"] = future_dt
+        if "updated_after" in params:
+            params["updated_after"] = future_dt
+
         try:
-            self.client.get(self.endpoint, created_after="2100-01-01 00:00:00",
-                           sort_by="id", sort_order="ascending")
+            self.client.get(self.endpoint, **params)
             return True
         except PardotForbiddenError:
             LOGGER.warning(

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -80,22 +80,20 @@ class Stream:
         if self.is_child_stream():
             return True
 
-        # Use the stream's normal query params to avoid passing unsupported filters,
-        # but force the time filter into the future so we don't fetch real data.
+        # Use the stream's normal query params — the caller (discover.py) already
+        # passes current date as start_date, so time filters are naturally current.
         params = dict(self.get_params() or {})
-        future_dt = "2100-01-01 00:00:00"
-        if "created_after" in params:
-            params["created_after"] = future_dt
-        if "updated_after" in params:
-            params["updated_after"] = future_dt
 
         try:
             self.client.get(self.endpoint, **params)
+            if self.stream_name == "visitors":
+                raise PardotForbiddenError("Simulated 403 for visitors")  # For testing purposes
             return True
-        except PardotForbiddenError:
+        except PardotForbiddenError as exc:
             LOGGER.warning(
-                "Stream '%s' does not have read permission, excluding from catalog.",
+                "Stream '%s' does not have read permission, excluding from catalog. Detail: %s",
                 self.stream_name,
+                str(exc),
             )
             return False
 

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -89,10 +89,10 @@ class Stream:
             return True
         except PardotForbiddenError as exc:
             LOGGER.warning(
-                    "Unauthorized Stream: %s, excluding '%s' from catalog.",
-                    str(exc),
-                    self.stream_name
-                )            
+                "Unauthorized Stream: %s, excluding from catalog. HTTP ERROR '%s'",
+                self.stream_name,
+                str(exc),
+            )
             return False
 
     def is_child_stream(self):

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -30,6 +30,7 @@ class Stream:
     replication_keys = []
     replication_method = None
     is_dynamic = False
+    parent_class = None
 
     client = None
     config = None
@@ -100,7 +101,7 @@ class Stream:
 
     def is_child_stream(self):
         """Return True if this stream is a child stream."""
-        return hasattr(self, 'parent_class') and self.parent_class is not None
+        return self.parent_class is not None
 
     def get_records(self):
         data = self.client.get(self.endpoint, **self.get_params())

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -3,6 +3,10 @@ import inspect
 import singer
 from dateutil.parser import parse as parse_datetime
 
+from .client import PardotForbiddenError
+
+LOGGER = singer.get_logger()
+
 PARDOT_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 
@@ -65,6 +69,26 @@ class Stream:
 
     def post_sync(self):
         """Function to run arbitrary code after a full sync completes."""
+
+    def check_access(self):
+        """
+        Verify that the API credentials have read access to this stream.
+        Returns True if accessible, False if a 403 Forbidden error is raised.
+        """
+        try:
+            self.client.get(self.endpoint, created_after="2100-01-01 00:00:00",
+                           sort_by="id", sort_order="ascending")
+            return True
+        except PardotForbiddenError:
+            LOGGER.warning(
+                "Stream '%s' does not have read permission, excluding from catalog.",
+                self.stream_name,
+            )
+            return False
+
+    def is_child_stream(self):
+        """Return True if this stream is a child stream."""
+        return hasattr(self, 'parent_class') and self.parent_class is not None
 
     def get_records(self):
         data = self.client.get(self.endpoint, **self.get_params())

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -86,8 +86,6 @@ class Stream:
 
         try:
             self.client.get(self.endpoint, **params)
-            if self.stream_name == "visitors":
-                raise PardotForbiddenError("Simulated 403 for visitors")  # For testing purposes
             return True
         except PardotForbiddenError as exc:
             LOGGER.warning(

--- a/tests/base.py
+++ b/tests/base.py
@@ -13,6 +13,7 @@ class PardotBaseTest(BaseCase):
     """
 
     start_date = "2020-01-01T00:00:00Z"
+    IS_FORBIDDEN_STREAM = "is-forbidden-stream"
 
     @staticmethod
     def tap_name():
@@ -98,8 +99,12 @@ class PardotBaseTest(BaseCase):
 
     @classmethod
     def expected_stream_names(cls):
-        """Return all expected stream names."""
-        return set(cls.expected_metadata().keys())
+        """The expected stream names and exclude forbidden streams."""
+        return {
+            stream_name
+            for stream_name, metadata in cls.expected_metadata().items()
+            if not metadata.get(cls.IS_FORBIDDEN_STREAM, False)
+        }
 
     @staticmethod
     def get_credentials():

--- a/tests/base.py
+++ b/tests/base.py
@@ -99,7 +99,7 @@ class PardotBaseTest(BaseCase):
 
     @classmethod
     def expected_stream_names(cls):
-        """The expected stream names and exclude forbidden streams."""
+        """Return expected stream names excluding forbidden streams."""
         return {
             stream_name
             for stream_name, metadata in cls.expected_metadata().items()

--- a/tests/tap_combined_test.py
+++ b/tests/tap_combined_test.py
@@ -33,6 +33,13 @@ class TapCombinedTest(unittest.TestCase):
 
     def expected_pks(self):
         return config["streams"]
+    
+    def expected_parent_streams(self):
+        """Return a mapping of child streams to their expected parent streams."""
+        return {
+            "list_memberships": "lists",
+            "visits": "visitors",
+        }
 
     def get_properties(self):
         """Configuration properties required for the tap."""
@@ -68,9 +75,6 @@ class TapCombinedTest(unittest.TestCase):
             if os.getenv(creds[cred]) == None:
                 missing_envs.append(cred)
 
-        import ipdb; ipdb.set_trace()
-        1+1
-
         if len(missing_envs) != 0:
             raise Exception("set " + ", ".join(missing_envs))
 
@@ -98,6 +102,27 @@ class TapCombinedTest(unittest.TestCase):
         self.assertTrue(
             subset, msg="Expected check streams are not subset of discovered catalog"
         )
+        
+        # Validate parent stream ids
+        for catalog in found_catalogs:
+            stream_id = catalog["tap_stream_id"]
+            
+            # Get the annotated schema to access metadata
+            schema_and_metadata = menagerie.get_annotated_schema(conn_id, stream_id)
+            metadata = schema_and_metadata["metadata"]
+            
+            # Get the top-level breadcrumb metadata
+            stream_properties = [item for item in metadata if item.get("breadcrumb") == []]
+            if stream_properties:
+                actual_parent_stream = stream_properties[0].get("metadata", {}).get("parent-tap-stream-id")
+                expected_parent_stream = self.expected_parent_streams().get(stream_id)
+                
+                self.assertEqual(
+                    expected_parent_stream,
+                    actual_parent_stream,
+                    msg=f"Expected parent-tap-stream-id to be {expected_parent_stream} for stream {stream_id}, but got {actual_parent_stream}",
+                )
+
         #
         # # Select some catalogs
         our_catalogs = [

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -317,7 +317,7 @@ class TestClientMakeRequest(unittest.TestCase):
             client._make_request("get", "https://pi.pardot.com/api/prospect/version/{}/do/query")
 
         error_msg = str(ctx.exception)
-        self.assertIn("HTTP 403 Forbidden", error_msg)
+        self.assertIn("HTTP-Error-Code: 403", error_msg)
         self.assertIn("prospect/version/4/do/query", error_msg)
         self.assertIn("Access denied", error_msg)
 
@@ -332,7 +332,7 @@ class TestClientMakeRequest(unittest.TestCase):
             client._make_request("get", "https://pi.pardot.com/api/visitor/version/{}/do/query")
 
         error_msg = str(ctx.exception)
-        self.assertIn("HTTP 403 Forbidden", error_msg)
+        self.assertIn("HTTP-Error-Code: 403", error_msg)
         self.assertIn("visitor/version/4/do/query", error_msg)
         self.assertIn("No additional details", error_msg)
 

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -17,10 +17,11 @@ from tap_pardot.client import (
 class MockResponse:
     """Mock HTTP response for testing."""
 
-    def __init__(self, status_code, json_data=None, raise_for_status_error=False):
+    def __init__(self, status_code, json_data=None, raise_for_status_error=False, text=""):
         self.status_code = status_code
         self.json_data = json_data or {}
         self.raise_for_status_error = raise_for_status_error
+        self.text = text
 
     def json(self):
         return self.json_data
@@ -303,6 +304,37 @@ class TestClientMakeRequest(unittest.TestCase):
 
         with self.assertRaises(Pardot5xxError):
             client._make_request("get", "https://pi.pardot.com/api/prospect/version/{}/do/query")
+
+    @patch("tap_pardot.client.requests.request")
+    def test_make_request_403_raises_forbidden_with_detail(self, mock_request):
+        """Test 403 response raises PardotForbiddenError with endpoint and API error detail."""
+        from tap_pardot.client import PardotForbiddenError
+        api_error_body = '{"err":"Access denied","@attributes":{"err_code":15}}'
+        mock_request.return_value = MockResponse(403, json_data={}, text=api_error_body)
+        client = self._create_client_with_oauth()
+
+        with self.assertRaises(PardotForbiddenError) as ctx:
+            client._make_request("get", "https://pi.pardot.com/api/prospect/version/{}/do/query")
+
+        error_msg = str(ctx.exception)
+        self.assertIn("HTTP 403 Forbidden", error_msg)
+        self.assertIn("prospect/version/4/do/query", error_msg)
+        self.assertIn("Access denied", error_msg)
+
+    @patch("tap_pardot.client.requests.request")
+    def test_make_request_403_empty_body(self, mock_request):
+        """Test 403 with empty response body still includes endpoint in error."""
+        from tap_pardot.client import PardotForbiddenError
+        mock_request.return_value = MockResponse(403, json_data={}, text="")
+        client = self._create_client_with_oauth()
+
+        with self.assertRaises(PardotForbiddenError) as ctx:
+            client._make_request("get", "https://pi.pardot.com/api/visitor/version/{}/do/query")
+
+        error_msg = str(ctx.exception)
+        self.assertIn("HTTP 403 Forbidden", error_msg)
+        self.assertIn("visitor/version/4/do/query", error_msg)
+        self.assertIn("No additional details", error_msg)
 
     @patch("tap_pardot.client.Client.login")
     @patch("tap_pardot.client.requests.request")

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -194,7 +194,7 @@ class TestClientLogin(unittest.TestCase):
 class TestClientRefreshCredentials(unittest.TestCase):
     """Test Client refresh_credentials method."""
 
-    @patch("tap_pardot.client.requests.request")
+    @patch("tap_pardot.client.requests.post")
     def test_refresh_credentials_success(self, mock_request):
         """Test successful credential refresh stores access_token."""
         mock_request.return_value = MockResponse(
@@ -216,7 +216,7 @@ class TestClientRefreshCredentials(unittest.TestCase):
 
         self.assertEqual(client.creds["access_token"], "new_access_token")
 
-    @patch("tap_pardot.client.requests.request")
+    @patch("tap_pardot.client.requests.post")
     def test_refresh_credentials_http_error(self, mock_request):
         """Test refresh_credentials raises on HTTP error."""
         mock_request.return_value = MockResponse(
@@ -235,8 +235,9 @@ class TestClientRefreshCredentials(unittest.TestCase):
             client.creds = creds
             client.api_version = "4"
 
-            with self.assertRaises(requests.HTTPError):
+            with self.assertRaises(Exception) as ctx:
                 client.refresh_credentials()
+            self.assertIn("OAuth token refresh failed with status 401", str(ctx.exception))
 
 
 class TestClientMakeRequest(unittest.TestCase):

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -321,7 +321,3 @@ class TestStreamCheckAccess(unittest.TestCase):
         stream = ListMemberships(client=client, config={"start_date": "2020-01-01T00:00:00Z"}, state={}, emit=False)
         self.assertTrue(stream.check_access())
         client.get.assert_not_called()
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -2,14 +2,16 @@ import os
 import unittest
 from unittest.mock import MagicMock, patch, mock_open
 
-from tap_pardot.discover import discover, _load_schemas, _get_abs_path, _parse_schema_description
+from tap_pardot.client import PardotForbiddenError
+from tap_pardot.discover import discover, _load_schemas, _get_abs_path, _parse_schema_description, _apply_access_checks, _prune_inaccessible_children
 
 
 class TestDiscover(unittest.TestCase):
     """Test discover function."""
 
+    @patch("tap_pardot.discover._apply_access_checks")
     @patch("tap_pardot.discover._load_schemas")
-    def test_discover_returns_catalog(self, mock_load_schemas):
+    def test_discover_returns_catalog(self, mock_load_schemas, mock_access_checks):
         """Test discover returns a valid Catalog object."""
         mock_load_schemas.return_value = {
             "prospects": {
@@ -28,8 +30,9 @@ class TestDiscover(unittest.TestCase):
         self.assertEqual(len(catalog.streams), 1)
         self.assertEqual(catalog.streams[0].stream, "prospects")
 
+    @patch("tap_pardot.discover._apply_access_checks")
     @patch("tap_pardot.discover._load_schemas")
-    def test_discover_multiple_streams(self, mock_load_schemas):
+    def test_discover_multiple_streams(self, mock_load_schemas, mock_access_checks):
         """Test discover returns catalog with multiple streams."""
         mock_load_schemas.return_value = {
             "prospects": {
@@ -55,8 +58,9 @@ class TestDiscover(unittest.TestCase):
         self.assertIn("prospects", stream_names)
         self.assertIn("campaigns", stream_names)
 
+    @patch("tap_pardot.discover._apply_access_checks")
     @patch("tap_pardot.discover._load_schemas")
-    def test_discover_sets_metadata(self, mock_load_schemas):
+    def test_discover_sets_metadata(self, mock_load_schemas, mock_access_checks):
         """Test discover sets correct metadata on catalog entries."""
         mock_load_schemas.return_value = {
             "email_clicks": {
@@ -158,6 +162,162 @@ class TestGetAbsPath(unittest.TestCase):
         result = _get_abs_path("schemas")
         self.assertTrue(os.path.isabs(result))
         self.assertTrue(result.endswith("schemas"))
+
+
+class TestApplyAccessChecks(unittest.TestCase):
+    """Test _apply_access_checks function."""
+
+    @patch("tap_pardot.discover.STREAM_OBJECTS")
+    def test_all_streams_accessible(self, mock_stream_objects):
+        """Test that all streams remain when all are accessible."""
+        client = MagicMock()
+        client.get.return_value = {"result": None}
+
+        mock_prospects_cls = MagicMock()
+        mock_prospects_instance = MagicMock()
+        mock_prospects_instance.check_access.return_value = True
+        mock_prospects_cls.return_value = mock_prospects_instance
+        mock_prospects_cls.parent_class = None
+
+        mock_stream_objects.get.return_value = mock_prospects_cls
+        mock_stream_objects.items.return_value = [("prospects", mock_prospects_cls)]
+        mock_stream_objects.__iter__ = lambda self: iter(["prospects"])
+
+        schemas = {"prospects": {"type": "object", "properties": {}}}
+        _apply_access_checks(client, schemas)
+
+        self.assertIn("prospects", schemas)
+
+    @patch("tap_pardot.discover.STREAM_OBJECTS")
+    def test_inaccessible_stream_excluded(self, mock_stream_objects):
+        """Test that inaccessible streams are excluded from schemas."""
+        client = MagicMock()
+
+        mock_prospects_cls = MagicMock()
+        mock_prospects_instance = MagicMock()
+        mock_prospects_instance.check_access.return_value = False
+        mock_prospects_cls.return_value = mock_prospects_instance
+        mock_prospects_cls.parent_class = None
+
+        mock_campaigns_cls = MagicMock()
+        mock_campaigns_instance = MagicMock()
+        mock_campaigns_instance.check_access.return_value = True
+        mock_campaigns_cls.return_value = mock_campaigns_instance
+        mock_campaigns_cls.parent_class = None
+
+        mock_stream_objects.get.side_effect = lambda k: {"prospects": mock_prospects_cls, "campaigns": mock_campaigns_cls}.get(k)
+        mock_stream_objects.items.return_value = [("prospects", mock_prospects_cls), ("campaigns", mock_campaigns_cls)]
+
+        schemas = {
+            "prospects": {"type": "object", "properties": {}},
+            "campaigns": {"type": "object", "properties": {}},
+        }
+        _apply_access_checks(client, schemas)
+
+        self.assertNotIn("prospects", schemas)
+        self.assertIn("campaigns", schemas)
+
+    @patch("tap_pardot.discover.STREAM_OBJECTS")
+    def test_all_streams_inaccessible_raises(self, mock_stream_objects):
+        """Test that PardotForbiddenError is raised when no streams are accessible."""
+        client = MagicMock()
+
+        mock_prospects_cls = MagicMock()
+        mock_prospects_instance = MagicMock()
+        mock_prospects_instance.check_access.return_value = False
+        mock_prospects_cls.return_value = mock_prospects_instance
+        mock_prospects_cls.parent_class = None
+        mock_prospects_cls.stream_name = "prospects"
+
+        mock_stream_objects.get.return_value = mock_prospects_cls
+        mock_stream_objects.items.return_value = [("prospects", mock_prospects_cls)]
+        mock_stream_objects.__getitem__ = lambda self, key: mock_prospects_cls
+
+        schemas = {"prospects": {"type": "object", "properties": {}}}
+
+        with self.assertRaises(PardotForbiddenError):
+            _apply_access_checks(client, schemas)
+
+
+class TestPruneInaccessibleChildren(unittest.TestCase):
+    """Test _prune_inaccessible_children function."""
+
+    @patch("tap_pardot.discover.STREAM_OBJECTS")
+    def test_child_excluded_when_parent_missing(self, mock_stream_objects):
+        """Test child streams are removed when their parent is not in schemas."""
+        from tap_pardot.streams import Visitors
+
+        mock_visits_cls = MagicMock()
+        mock_visits_cls.parent_class = Visitors
+        mock_visits_cls.parent_class.stream_name = "visitors"
+
+        mock_stream_objects.items.return_value = [("visits", mock_visits_cls)]
+
+        schemas = {"visits": {"type": "object", "properties": {}}}
+        _prune_inaccessible_children(schemas)
+
+        self.assertNotIn("visits", schemas)
+
+    @patch("tap_pardot.discover.STREAM_OBJECTS")
+    def test_child_kept_when_parent_present(self, mock_stream_objects):
+        """Test child streams remain when their parent is in schemas."""
+        from tap_pardot.streams import Visitors
+
+        mock_visits_cls = MagicMock()
+        mock_visits_cls.parent_class = Visitors
+        mock_visits_cls.parent_class.stream_name = "visitors"
+
+        mock_stream_objects.items.return_value = [("visits", mock_visits_cls)]
+
+        schemas = {
+            "visitors": {"type": "object", "properties": {}},
+            "visits": {"type": "object", "properties": {}},
+        }
+        _prune_inaccessible_children(schemas)
+
+        self.assertIn("visits", schemas)
+
+
+class TestStreamCheckAccess(unittest.TestCase):
+    """Test Stream.check_access() method."""
+
+    def test_check_access_returns_true_on_success(self):
+        """Test check_access returns True when API call succeeds."""
+        from tap_pardot.streams import Prospects
+
+        client = MagicMock()
+        client.get.return_value = {"result": None}
+
+        stream = Prospects(client=client, config={"start_date": "2020-01-01T00:00:00Z"}, state={}, emit=False)
+        self.assertTrue(stream.check_access())
+
+    def test_check_access_returns_false_on_403(self):
+        """Test check_access returns False when PardotForbiddenError is raised."""
+        from tap_pardot.streams import Prospects
+
+        client = MagicMock()
+        client.get.side_effect = PardotForbiddenError("403 Forbidden")
+
+        stream = Prospects(client=client, config={"start_date": "2020-01-01T00:00:00Z"}, state={}, emit=False)
+        self.assertFalse(stream.check_access())
+
+    def test_check_access_child_stream_also_checked(self):
+        """Test check_access checks child streams independently when called."""
+        from tap_pardot.streams import Visits
+
+        client = MagicMock()
+        client.get.side_effect = PardotForbiddenError("403 Forbidden")
+        stream = Visits(client=client, config={"start_date": "2020-01-01T00:00:00Z"}, state={}, emit=False)
+        self.assertFalse(stream.check_access())
+
+    def test_check_access_child_stream_accessible(self):
+        """Test check_access returns True for accessible child streams."""
+        from tap_pardot.streams import Visits
+
+        client = MagicMock()
+        client.get.return_value = {"result": None}
+        stream = Visits(client=client, config={"start_date": "2020-01-01T00:00:00Z"}, state={}, emit=False)
+        self.assertTrue(stream.check_access())
 
 
 if __name__ == "__main__":

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -207,6 +207,7 @@ class TestApplyAccessChecks(unittest.TestCase):
 
         mock_stream_objects.get.side_effect = lambda k: {"prospects": mock_prospects_cls, "campaigns": mock_campaigns_cls}.get(k)
         mock_stream_objects.items.return_value = [("prospects", mock_prospects_cls), ("campaigns", mock_campaigns_cls)]
+        mock_stream_objects.__getitem__ = lambda self, key: {"prospects": mock_prospects_cls, "campaigns": mock_campaigns_cls}[key]
 
         schemas = {
             "prospects": {"type": "object", "properties": {}},
@@ -231,7 +232,7 @@ class TestApplyAccessChecks(unittest.TestCase):
 
         mock_stream_objects.get.return_value = mock_prospects_cls
         mock_stream_objects.items.return_value = [("prospects", mock_prospects_cls)]
-        mock_stream_objects.__getitem__ = lambda self, key: mock_prospects_cls
+        mock_stream_objects.__getitem__ = lambda self, key: {"prospects": mock_prospects_cls}[key]
 
         schemas = {"prospects": {"type": "object", "properties": {}}}
 
@@ -301,23 +302,25 @@ class TestStreamCheckAccess(unittest.TestCase):
         stream = Prospects(client=client, config={"start_date": "2020-01-01T00:00:00Z"}, state={}, emit=False)
         self.assertFalse(stream.check_access())
 
-    def test_check_access_child_stream_also_checked(self):
-        """Test check_access checks child streams independently when called."""
+    def test_check_access_child_stream_always_true(self):
+        """Test check_access always returns True for child streams without making API calls."""
         from tap_pardot.streams import Visits
 
         client = MagicMock()
         client.get.side_effect = PardotForbiddenError("403 Forbidden")
         stream = Visits(client=client, config={"start_date": "2020-01-01T00:00:00Z"}, state={}, emit=False)
-        self.assertFalse(stream.check_access())
+        # Child streams always return True — access governed by parent
+        self.assertTrue(stream.check_access())
+        client.get.assert_not_called()
 
-    def test_check_access_child_stream_accessible(self):
-        """Test check_access returns True for accessible child streams."""
-        from tap_pardot.streams import Visits
+    def test_check_access_child_stream_does_not_call_api(self):
+        """Test check_access for child streams skips API call entirely."""
+        from tap_pardot.streams import ListMemberships
 
         client = MagicMock()
-        client.get.return_value = {"result": None}
-        stream = Visits(client=client, config={"start_date": "2020-01-01T00:00:00Z"}, state={}, emit=False)
+        stream = ListMemberships(client=client, config={"start_date": "2020-01-01T00:00:00Z"}, state={}, emit=False)
         self.assertTrue(stream.check_access())
+        client.get.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description of change
https://qlik-dev.atlassian.net/browse/SAC-30930
Excluded unauthorized streams from catalog during discovery
Child streams are automatically excluded when their parent stream is inaccessible.
Added unit test case and updated integration test accordingly

# Manual QA steps
  - [x]  Discovery: Running
 - [x]  Sync: Running
 - [x]  Unit Tests: Running
 - [x]  Integration test: Running 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
